### PR TITLE
Fix the endpoints to include database name for ::databaseBackup() and ::restoreDatabaseBackup()

### DIFF
--- a/src/CloudApi/Client.php
+++ b/src/CloudApi/Client.php
@@ -292,15 +292,16 @@ class Client implements ClientInterface
      * Gets information about a database backup.
      *
      * @param string $environmentUuid
+     * @param string $dbName
      * @param int    $backupId
      * @return BackupResponse
      */
-    public function databaseBackup($environmentUuid, $backupId)
+    public function databaseBackup($environmentUuid, $dbName, $backupId)
     {
         return new BackupResponse(
             $this->connector->request(
                 'get',
-                "/environments/${environmentUuid}/database-backups/${backupId}",
+                "/environments/${environmentUuid}/databases/${dbName}/backups/${backupId}",
                 $this->query
             )
         );
@@ -310,15 +311,16 @@ class Client implements ClientInterface
      * Restores a database backup to a database in an environment.
      *
      * @param string $environmentUuid
+     * @param string $dbName
      * @param int    $backupId
      * @return OperationResponse
      */
-    public function restoreDatabaseBackup($environmentUuid, $backupId)
+    public function restoreDatabaseBackup($environmentUuid, $dbName, $backupId)
     {
         return new OperationResponse(
             $this->connector->request(
                 'post',
-                "/environments/${environmentUuid}/database-backups/${backupId}/actions/restore",
+                "/environments/${environmentUuid}/databases/${dbName}/backups/${backupId}/actions/restore",
                 $this->query
             )
         );

--- a/src/CloudApi/ClientInterface.php
+++ b/src/CloudApi/ClientInterface.php
@@ -150,19 +150,21 @@ interface ClientInterface
      * Gets information about a database backup.
      *
      * @param string $environmentUuid
+     * @param string $dbName
      * @param int    $backupId
      * @return BackupResponse
      */
-    public function databaseBackup($environmentUuid, $backupId);
+    public function databaseBackup($environmentUuid, $dbName, $backupId);
 
     /**
      * Restores a database backup to a database in an environment.
      *
      * @param string $environmentUuid
+     * @param string $dbName
      * @param int    $backupId
      * @return OperationResponse
      */
-    public function restoreDatabaseBackup($environmentUuid, $backupId);
+    public function restoreDatabaseBackup($environmentUuid, $dbName, $backupId);
 
     /**
      * Copies files from an environment to another environment.

--- a/tests/Endpoints/DatabasesTest.php
+++ b/tests/Endpoints/DatabasesTest.php
@@ -136,7 +136,7 @@ class DatabasesTest extends CloudApiTestCase
         $client = $this->getMockClient($response);
 
         /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
-        $result = $client->databaseBackup('24-a47ac10b-58cc-4372-a567-0e02b2c3d470', 12);
+        $result = $client->databaseBackup('24-a47ac10b-58cc-4372-a567-0e02b2c3d470', 'db_name', 12);
 
         $this->assertNotInstanceOf('\AcquiaCloudApi\Response\BackupsResponse', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\BackupResponse', $result);
@@ -152,7 +152,7 @@ class DatabasesTest extends CloudApiTestCase
         $client = $this->getMockClient($response);
 
         /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
-        $result = $client->restoreDatabaseBackup('24-a47ac10b-58cc-4372-a567-0e02b2c3d470', 12);
+        $result = $client->restoreDatabaseBackup('24-a47ac10b-58cc-4372-a567-0e02b2c3d470', 'db_name', 12);
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
 


### PR DESCRIPTION
It seems the endpoints must have changed for retrieving info on or restoring database backups to require the database name.

See https://cloud.acquia.com/api-docs/#environments

![cloud api documentation 2018-12-18 11-06-09](https://user-images.githubusercontent.com/66118/50166393-f805a880-02b4-11e9-920c-423a49df1265.png)
