### PR TITLE
Add Notification class for getting information about a Notification

### DIFF
--- a/src/CloudApi/Client.php
+++ b/src/CloudApi/Client.php
@@ -17,6 +17,7 @@ use AcquiaCloudApi\Response\EnvironmentsResponse;
 use AcquiaCloudApi\Response\InsightsResponse;
 use AcquiaCloudApi\Response\InvitationsResponse;
 use AcquiaCloudApi\Response\MembersResponse;
+use AcquiaCloudApi\Response\NotificationResponse;
 use AcquiaCloudApi\Response\OperationResponse;
 use AcquiaCloudApi\Response\OrganizationsResponse;
 use AcquiaCloudApi\Response\PermissionsResponse;
@@ -101,6 +102,22 @@ class Client implements ClientInterface
     public function account()
     {
         return new AccountResponse($this->connector->request('get', '/account', $this->query));
+    }
+
+    /**
+     * Returns details about your account.
+     *
+     * @return NotificationResponse
+     */
+    public function notification($notificationUuid)
+    {
+        return new NotificationResponse(
+            $this->connector->request(
+                'get',
+                "/notifications/${notificationUuid}",
+                $this->query
+            )
+        );
     }
 
     /**

--- a/src/CloudApi/ClientInterface.php
+++ b/src/CloudApi/ClientInterface.php
@@ -17,6 +17,7 @@ use AcquiaCloudApi\Response\EnvironmentsResponse;
 use AcquiaCloudApi\Response\InsightsResponse;
 use AcquiaCloudApi\Response\InvitationsResponse;
 use AcquiaCloudApi\Response\MembersResponse;
+use AcquiaCloudApi\Response\NotificationResponse;
 use AcquiaCloudApi\Response\OperationResponse;
 use AcquiaCloudApi\Response\OrganizationsResponse;
 use AcquiaCloudApi\Response\PermissionsResponse;
@@ -66,6 +67,15 @@ interface ClientInterface
      * @return ApplicationsResponse
      */
     public function applications();
+
+
+    /**
+     * Returns details about a notification.
+     *
+     * @param string $notificationUuid
+     * @return NotificationResponse
+     */
+    public function notification($notificationUuid);
 
     /**
      * Shows information about an application.

--- a/src/Response/NotificationResponse.php
+++ b/src/Response/NotificationResponse.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace AcquiaCloudApi\Response;
+
+/**
+ * Class NotificationResponse
+ * @package AcquiaCloudApi\Response
+ */
+class NotificationResponse
+{
+    public $uuid;
+    public $event;
+    public $label;
+    public $description;
+    public $created_at;
+    public $completed_at;
+    public $status;
+    public $progress;
+    public $context;
+    public $links;
+
+
+    /**
+     * MemberResponse constructor.
+     * @param object $notification
+     */
+    public function __construct($notification)
+    {
+        $this->uuid = $notification->uuid;
+        $this->event = $notification->event;
+        $this->label = $notification->label;
+        $this->description = $notification->description;
+        $this->created_at = $notification->created_at;
+        $this->completed_at = $notification->completed_at;
+        $this->status = $notification->status;
+        $this->progress = $notification->progress;
+        $this->context = $notification->context;
+        $this->links = $notification->_links;
+    }
+}

--- a/tests/Endpoints/NotificationTest.php
+++ b/tests/Endpoints/NotificationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use AcquiaCloudApi\CloudApi\Client;
+
+class NotificationTest extends CloudApiTestCase
+{
+
+    protected $properties = [
+    'uuid',
+    'event',
+    'label',
+    'description',
+    'created_at',
+    'completed_at',
+    'status',
+    'progress',
+    'context',
+    'links'
+    ];
+
+    public function testGetNotification()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/getNotification.json');
+        $client = $this->getMockClient($response);
+
+      /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
+        $result = $client->notification('f4b37e3c-1g96-4ed4-ad20-3081fe0f9545');
+
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\NotificationResponse', $result);
+
+        foreach ($this->properties as $property) {
+            $this->assertObjectHasAttribute($property, $result);
+        }
+    }
+}

--- a/tests/Fixtures/Endpoints/getNotification.json
+++ b/tests/Fixtures/Endpoints/getNotification.json
@@ -1,0 +1,69 @@
+{
+    "uuid": "f4b37e3c-1g96-4ed4-ad20-3081fe0f9545",
+    "event": "DatabaseBackupCreated",
+    "label": "Database backup created",
+    "description": "A \"sample_db\" database backup has been created for \"Dev\".",
+    "created_at": "2019-09-23T15:59:39+00:00",
+    "completed_at": "2019-09-23T16:01:16+00:00",
+    "status": "completed",
+    "progress": 100,
+    "context": {
+        "database": {
+            "names": [
+                "sample_db"
+            ]
+        },
+        "environment": {
+            "ids": [
+                "5333-3580d1ec-cf2b-1624-5d85-0d11ecd9a69a"
+            ]
+        },
+        "application": {
+            "uuids": [
+                "3580d1ec-cfgb-1624-5d85-0d28g2d9n69a"
+            ]
+        },
+        "team": {
+            "uuids": [
+                "3cb395d2-7cba-1fh4-b588-22000b04072f",
+                "a31ba519-4ec3-47c9-9dd1-b509g3fb618f"
+            ]
+        },
+        "organization": {
+            "uuids": [
+                "26416235-7cba-11e4-b567-200200b04072f"
+            ]
+        },
+        "subscription": {
+            "uuids": [
+                "863aa975-b9b9-4c55-9b1f-90e31293ad30"
+            ]
+        },
+        "author": {
+            "uuid": "a58b046c-dd0c-102e-8305-1231f10f2cc1",
+            "actual_uuid": "a58b046c-dd0c-102e-8305-1231f10f2cc1"
+        },
+        "user": {
+            "uuids": [
+                "a58b046c-dd0c-102e-8305-1231f10f2cc1"
+            ]
+        }
+    },
+    "_links": {
+        "self": {
+            "href": "https:\/\/cloud.acquia.com\/api\/notifications\/f4b37e3c-1g96-4ed4-ad20-3081fe0f9545"
+        }
+    },
+    "_embedded": {
+        "author": {
+            "uuid": "a58b046c-dd0c-102e-8305-1231f10f2cc1",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "last_login_at": "2019-09-22T12:20:20+00:00",
+            "created_at": "2017-03-28T13:07:54-0500",
+            "email": "jane.doe@example.com",
+            "picture_url": "https:\/\/accounts.acquia.com\/images\/users\/a58b046c-dd0c-102e-8305-1231f10f2cc1\/style\/avatar",
+            "username": "jane.doe"
+        }
+    }
+}


### PR DESCRIPTION
Now that [Notifications|https://docs.acquia.com/acquia-cloud/develop/api/notifications/] are a thing, thought it might be nice to get the base class in before starting to change other classes to take advantage. 

Might need some work to have a method to get by full path instead of just UUID since the modified responses only provide an `href` value.