### PR TITLE
Namespace test classes

### DIFF
--- a/tests/CloudApiTestCase.php
+++ b/tests/CloudApiTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace AcquiaCloudApi\Tests;
+
 use AcquiaCloudApi\CloudApi\Client;
 use GuzzleHttp\Psr7;
 use PHPUnit\Framework\TestCase;

--- a/tests/Endpoints/AccountTest.php
+++ b/tests/Endpoints/AccountTest.php
@@ -1,6 +1,8 @@
 <?php
 
-use AcquiaCloudApi\CloudApi\Client;
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
 
 class AccountTest extends CloudApiTestCase
 {

--- a/tests/Endpoints/ApplicationsTest.php
+++ b/tests/Endpoints/ApplicationsTest.php
@@ -1,6 +1,8 @@
 <?php
 
-use AcquiaCloudApi\CloudApi\Client;
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
 
 class ApplicationsTest extends CloudApiTestCase
 {

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -1,8 +1,10 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
 use AcquiaCloudApi\CloudApi\Client;
 use AcquiaCloudApi\CloudApi\Connector;
-use GuzzleHttp\Client as GuzzleClient;
 
 class ClientTest extends CloudApiTestCase
 {

--- a/tests/Endpoints/CodeTest.php
+++ b/tests/Endpoints/CodeTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class CodeTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/CronsTest.php
+++ b/tests/Endpoints/CronsTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class CronsTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/DatabasesTest.php
+++ b/tests/Endpoints/DatabasesTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class DatabasesTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/DomainsTest.php
+++ b/tests/Endpoints/DomainsTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class DomainsTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/DrushTest.php
+++ b/tests/Endpoints/DrushTest.php
@@ -1,6 +1,8 @@
 <?php
 
-use AcquiaCloudApi\CloudApi\Client;
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
 
 class DrushTest extends CloudApiTestCase
 {

--- a/tests/Endpoints/EnvironmentsTest.php
+++ b/tests/Endpoints/EnvironmentsTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class EnvironmentsTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/ErrorTest.php
+++ b/tests/Endpoints/ErrorTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class ErrorTest extends CloudApiTestCase
 {
 
@@ -12,7 +16,7 @@ class ErrorTest extends CloudApiTestCase
         try {
           /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
             $client->applications();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->assertEquals($e->getMessage(), 'You do not have permission to view applications.');
 
             return;
@@ -30,7 +34,7 @@ class ErrorTest extends CloudApiTestCase
         try {
           /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
             $client->applications();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->assertEquals($e->getMessage(), 'The application you are trying to access does not exist, or you do not have permission to access it.');
 
             return;

--- a/tests/Endpoints/FilesTest.php
+++ b/tests/Endpoints/FilesTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class FilesTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/FiltersTest.php
+++ b/tests/Endpoints/FiltersTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class FiltersTest extends CloudApiTestCase
 {
 
@@ -61,7 +65,7 @@ class FiltersTest extends CloudApiTestCase
 
     public function getPrivateProperty($className, $propertyName)
     {
-        $reflector = new ReflectionClass($className);
+        $reflector = new \ReflectionClass($className);
         $property = $reflector->getProperty($propertyName);
         $property->setAccessible(true);
 

--- a/tests/Endpoints/InsightsTest.php
+++ b/tests/Endpoints/InsightsTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class InsightsTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/InvitesTest.php
+++ b/tests/Endpoints/InvitesTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class InvitesTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/LiveDevTest.php
+++ b/tests/Endpoints/LiveDevTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class LiveDevTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/MembersTest.php
+++ b/tests/Endpoints/MembersTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class MembersTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/OrganizationsTest.php
+++ b/tests/Endpoints/OrganizationsTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class OrganizationsTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/PermissionsTest.php
+++ b/tests/Endpoints/PermissionsTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class PermissionsTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/ProductionModeTest.php
+++ b/tests/Endpoints/ProductionModeTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class ProductionModeTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/RolesTest.php
+++ b/tests/Endpoints/RolesTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class RolesTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/ServersTest.php
+++ b/tests/Endpoints/ServersTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class ServersTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class TasksTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/TeamsTest.php
+++ b/tests/Endpoints/TeamsTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class TeamsTest extends CloudApiTestCase
 {
 

--- a/tests/Endpoints/VarnishTest.php
+++ b/tests/Endpoints/VarnishTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+
 class VarnishTest extends CloudApiTestCase
 {
 


### PR DESCRIPTION
Currently the test classes are not namespaced. This PR adds PSR-4 namespacing to all test classes.

### Motivation

I'd like to reuse some of the functionality in here to add tests to the https://github.com/Lullabot/robo-acquia project. As it stands, there is no way to reference the test classes in here because they are not namespaced. If you have another recommendation to achieve this, that's great too!