### PR TITLE
Adding leave and change-owner to organizations

### DIFF
--- a/src/Endpoints/Organizations.php
+++ b/src/Endpoints/Organizations.php
@@ -29,10 +29,9 @@ class Organizations extends CloudApiBase implements CloudApiInterface
     }
 
     /**
-     * Show all applications in an organisation.
+     * Show all applications in an organization.
      *
      * @param string $organizationUuid
-     *
      * @return ApplicationsResponse
      */
     public function getApplications($organizationUuid)
@@ -43,7 +42,7 @@ class Organizations extends CloudApiBase implements CloudApiInterface
     }
 
     /**
-     * Show all members of an organisation.
+     * Show all members of an organization.
      *
      * @param  string $organizationUuid
      * @return MembersResponse
@@ -70,7 +69,7 @@ class Organizations extends CloudApiBase implements CloudApiInterface
     }
 
     /**
-     * Show all admins of an organisation.
+     * Show all admins of an organization.
      *
      * @param  string $organizationUuid
      * @return MembersResponse
@@ -97,7 +96,7 @@ class Organizations extends CloudApiBase implements CloudApiInterface
     }
 
     /**
-     * Show all members invited to an organisation.
+     * Show all members invited to an organization.
      *
      * @param  string $organizationUuid
      * @return InvitationsResponse
@@ -110,7 +109,7 @@ class Organizations extends CloudApiBase implements CloudApiInterface
     }
 
     /**
-     * Delete a member from an organisation.
+     * Delete a member from an organization.
      *
      * @param  string $organizationUuid
      * @param  string $memberUuid
@@ -122,6 +121,45 @@ class Organizations extends CloudApiBase implements CloudApiInterface
             $this->client->request(
                 'delete',
                 "/organizations/${organizationUuid}/members/${memberUuid}"
+            )
+        );
+    }
+
+    /**
+     * Leave an organization.
+     *
+     * @param string $organizationUuid
+     * @return OperationResponse
+     */
+    public function leaveOrganization($organizationUuid)
+    {
+        return new OperationResponse(
+            $this->client->request(
+                'post',
+                "/organizations/${organizationUuid}/actions/leave"
+            )
+        );
+    }
+
+    /**
+     * Change the owner of an organization.
+     *
+     * @param string $organizationUuid
+     * @param string $newOwnerUuid
+     * @return OperationResponse
+     */
+    public function changeOwner($organizationUuid, $newOwnerUuid)
+    {
+        $options = [
+            'json' => [
+                'user_uuid' => $newOwnerUuid,
+            ],
+        ];
+        return new OperationResponse(
+            $this->client->request(
+                'post',
+                "/organizations/${organizationUuid}/actions/change-owner",
+                $options
             )
         );
     }

--- a/tests/Endpoints/OrganizationsTest.php
+++ b/tests/Endpoints/OrganizationsTest.php
@@ -156,6 +156,19 @@ class OrganizationsTest extends CloudApiTestCase
         }
     }
 
+    public function testLeaveOrganization()
+    {
+        $response = $this->getPsr7GzipResponseForFixture('Endpoints/Organizations/leaveOrganization.json');
+        $client = $this->getMockClient($response);
+
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
+        $organization = new Organizations($client);
+        $result  = $organization->leaveOrganization('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851');
+
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $this->assertEquals('Left organization.', $result->message);
+    }
+
     public function testChangeOwner()
     {
         $response = $this->getPsr7GzipResponseForFixture('Endpoints/Organizations/changeOwner.json');

--- a/tests/Endpoints/OrganizationsTest.php
+++ b/tests/Endpoints/OrganizationsTest.php
@@ -155,4 +155,20 @@ class OrganizationsTest extends CloudApiTestCase
             }
         }
     }
+
+    public function testChangeOwner()
+    {
+        $response = $this->getPsr7GzipResponseForFixture('Endpoints/Organizations/changeOwner.json');
+        $client = $this->getMockClient($response);
+
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
+        $organization = new Organizations($client);
+        $result  = $organization->changeOwner(
+            '14-0c7e79ab-1c4a-424e-8446-76ae8be7e851',
+            '82cff7ec-2f09-11e9-b210-d663bd873d93'
+        );
+
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $this->assertEquals("Changed organization owner.", $result->message);
+    }
 }

--- a/tests/Fixtures/Endpoints/Organizations/changeOwner.json
+++ b/tests/Fixtures/Endpoints/Organizations/changeOwner.json
@@ -1,0 +1,3 @@
+{
+    "message": "Changed organization owner."
+}

--- a/tests/Fixtures/Endpoints/Organizations/leaveOrganization.json
+++ b/tests/Fixtures/Endpoints/Organizations/leaveOrganization.json
@@ -1,0 +1,3 @@
+{
+    "message": "Left organization."
+}


### PR DESCRIPTION
I also changed the comment to use the consistent American spelling of organization since all of the methods and classes use that…

Not sure what tests need to be added as methods such as `deleteMember` don't seem to be tested either.

Also, the $options is marked as `json` assuming that #82 is merged… otherwise we should revert it to `form_params`