### PR TITLE
Allows request options to be accessed in tests

### DIFF
--- a/.github/workflows/mt.yml
+++ b/.github/workflows/mt.yml
@@ -1,0 +1,57 @@
+name: Mutation Testing
+
+on:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version: ['7.4']
+
+    name: Mutation Testing Code Review Annotations ${{ matrix.php-version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer:v2
+          extensions: pcov
+          coverage: pcov
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php-versions }}-
+
+      - name: Install dependencies
+        run: |
+          composer install --prefer-source --no-progress --no-suggest --no-interaction
+
+      - name: Setup PCOV
+        run: |
+          composer require pcov/clobber
+          vendor/bin/pcov clobber
+
+      - name: Download Infection
+        run: |
+          wget https://github.com/infection/infection/releases/download/0.20.0/infection.phar
+          chmod +x infection.phar
+
+      - name: Run Infection for added files only
+        env:
+          INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
+        run: |
+          git fetch --depth=1 origin $GITHUB_BASE_REF
+          php infection.phar -j2 --git-diff-filter=A --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --ignore-msi-with-no-mutations --only-covered

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -36,11 +36,13 @@ jobs:
     - name: Validate composer.json and composer.lock
       run: composer validate
 
-    - name: Cache Composer packages
+    - name: Get Composer Cache Directory
       id: composer-cache
-      uses: actions/cache@v2
+      run: |
+        echo "::set-output name=dir::$(composer config cache-files-dir)"
+    - uses: actions/cache@v2
       with:
-        path: vendor
+        path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-php-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
           ${{ runner.os }}-php-${{ matrix.php-versions }}-

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,16 @@
+{
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "tests/logs/infection.log",
+        "badge": {
+            "branch": "master"
+        }
+    },
+    "mutators": {
+        "@default": true
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,9 +2,9 @@ parameters:
     ignoreErrors:
         -
             message: '#Access to an undefined property Eloquent\\Phony\\Mock\\Handle\\InstanceHandle::\$[a-zA-Z\_]+.#'
-            path: tests/Endpoints/ConnectorTest.php
+            path: tests/Connector/ConnectorTest.php
         -
             message: '%Parameter #1 \$client of method League\\OAuth2\\Client\\Provider\\AbstractProvider::setHttpClient\(\) expects GuzzleHttp\\ClientInterface, Eloquent\\Phony\\Mock\\Mock given.%'
-            path: tests/Endpoints/ConnectorTest.php
+            path: tests/Connector/ConnectorTest.php
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon

--- a/src/Connector/Client.php
+++ b/src/Connector/Client.php
@@ -30,6 +30,11 @@ class Client implements ClientInterface
     protected $options = [];
 
     /**
+     * @var array Request options from each individual API call.
+     */
+    private $requestOptions = [];
+
+    /**
      * Client constructor.
      *
      * @param ConnectorInterface $connector
@@ -73,10 +78,10 @@ class Client implements ClientInterface
     /**
      * Allows the library to modify the request prior to making the call to the API.
      */
-    public function modifyOptions($options = []): array
+    public function modifyOptions(): array
     {
         // Combine options set globally e.g. headers with options set by individual API calls e.g. form_params.
-        $options = $this->options + $options;
+        $options = $this->options + $this->requestOptions;
 
         // This library can be standalone or as a dependency. Dependent libraries may also set their own user agent
         // which will make $options['headers']['User-Agent'] an array.
@@ -112,7 +117,9 @@ class Client implements ClientInterface
         // @TODO follow this up by removing $options from the parameters able
         // to be passed into this function and instead solely relying on the
         // addOption() method as this can then be tested.
-        $options = $this->modifyOptions($options);
+        $this->requestOptions = $options;
+
+        $this->modifyOptions();
 
         $response = $this->makeRequest($verb, $path, $options);
 

--- a/src/Connector/Client.php
+++ b/src/Connector/Client.php
@@ -114,14 +114,15 @@ class Client implements ClientInterface
      */
     public function request(string $verb, string $path, array $options = [])
     {
-        // @TODO follow this up by removing $options from the parameters able
-        // to be passed into this function and instead solely relying on the
-        // addOption() method as this can then be tested.
+        // Put options sent with API calls into a property so they can be accessed
+        // and therefore tested in tests.
         $this->requestOptions = $options;
 
-        $this->modifyOptions();
+        // Modify the options to combine options set as part of the API call as well
+        // as those set my tools extending this library.
+        $modifiedOptions = $this->modifyOptions();
 
-        $response = $this->makeRequest($verb, $path, $options);
+        $response = $this->makeRequest($verb, $path, $modifiedOptions);
 
         return $this->processResponse($response);
     }

--- a/src/Connector/Connector.php
+++ b/src/Connector/Connector.php
@@ -68,9 +68,8 @@ class Connector implements ConnectorInterface
     {
         if (!isset($this->accessToken) || $this->accessToken->hasExpired()) {
             $directory = sprintf('%s%s%s', Path::getHomeDirectory(), \DIRECTORY_SEPARATOR, '.acquia-php-sdk-v2');
-            $cache = new FilesystemAdapter('cache', 0, $directory);
+            $cache = new FilesystemAdapter('cache', 300, $directory);
             $accessToken = $cache->get('cloudapi-token', function (ItemInterface $item) {
-                $item->expiresAfter(300);
                 return $this->provider->getAccessToken('client_credentials');
             });
 

--- a/src/Exception/ApiErrorException.php
+++ b/src/Exception/ApiErrorException.php
@@ -16,6 +16,11 @@ class ApiErrorException extends Exception
     private $responseBody;
 
     /**
+     * @var string
+     */
+    private $errorType;
+
+    /**
      * ApiErrorException Constructor.
      *
      * @param object    $response_body
@@ -36,11 +41,11 @@ class ApiErrorException extends Exception
      */
     public function __toString()
     {
-        return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
+        return __CLASS__ . ": [{$this->errorType}]: {$this->message}\n";
     }
 
     /**
-     * Sets message and code properties.
+     * Sets message and errorType properties.
      *
      * @param object $response_body
      */
@@ -53,7 +58,7 @@ class ApiErrorException extends Exception
             }
             $this->message = $output;
         } else {
-            $this->code = $response_body->error;
+            $this->errorType = $response_body->error;
             $this->message = $response_body->message;
         }
     }

--- a/src/Exception/ApiErrorException.php
+++ b/src/Exception/ApiErrorException.php
@@ -44,7 +44,7 @@ class ApiErrorException extends Exception
      *
      * @param object $response_body
      */
-    public function setError($response_body)
+    private function setError($response_body)
     {
         if (is_array($response_body->message) || is_object($response_body->message)) {
             $output = '';

--- a/tests/CloudApiTestCase.php
+++ b/tests/CloudApiTestCase.php
@@ -54,7 +54,6 @@ abstract class CloudApiTestCase extends TestCase
     protected function getPsr7GzipResponseForFixture($fixture, $statusCode = 200): Psr7\Response
     {
         $stream = $this->getPsr7StreamForFixture($fixture);
-        $this->assertEquals(JSON_ERROR_NONE, json_last_error());
 
         return new Psr7\Response($statusCode, ['Content-Type' => 'application/octet-stream'], $stream);
     }

--- a/tests/CloudApiTestCase.php
+++ b/tests/CloudApiTestCase.php
@@ -15,7 +15,7 @@ abstract class CloudApiTestCase extends TestCase
     /**
      * Returns a PSR7 Stream for a given fixture.
      *
-     * @param  string     $fixture The fixture to create the stream for.
+     * @param  string $fixture The fixture to create the stream for.
      * @return Psr7\Stream
      */
     protected function getPsr7StreamForFixture($fixture): Psr7\Stream
@@ -31,8 +31,8 @@ abstract class CloudApiTestCase extends TestCase
     /**
      * Returns a PSR7 Response (JSON) for a given fixture.
      *
-     * @param  string        $fixture    The fixture to create the response for.
-     * @param  integer       $statusCode A HTTP Status Code for the response.
+     * @param  string  $fixture    The fixture to create the response for.
+     * @param  integer $statusCode A HTTP Status Code for the response.
      * @return Psr7\Response
      */
     protected function getPsr7JsonResponseForFixture($fixture, $statusCode = 200): Psr7\Response
@@ -47,8 +47,8 @@ abstract class CloudApiTestCase extends TestCase
     /**
      * Returns a PSR7 Response (Gzip) for a given fixture.
      *
-     * @param  string        $fixture    The fixture to create the response for.
-     * @param  integer       $statusCode A HTTP Status Code for the response.
+     * @param  string  $fixture    The fixture to create the response for.
+     * @param  integer $statusCode A HTTP Status Code for the response.
      * @return Psr7\Response
      */
     protected function getPsr7GzipResponseForFixture($fixture, $statusCode = 200): Psr7\Response
@@ -62,10 +62,10 @@ abstract class CloudApiTestCase extends TestCase
     /**
      * Mock client class.
      *
-     * @param  mixed  $response
+     * @param  mixed $response
      * @return Client
      */
-    protected function getMockClient($response = '')
+    protected function getMockClient($response = ''): Client
     {
         if ($response) {
             $connector = $this
@@ -88,5 +88,19 @@ abstract class CloudApiTestCase extends TestCase
         $client = Client::factory($connector);
 
         return $client;
+    }
+
+    /**
+     * Uses reflection to retrieve the internal request options to test passed parameters.
+     *
+     * @param  Client $client
+     * @return array
+     */
+    protected function getRequestOptions($client): array
+    {
+        $reflectionClass = new \ReflectionClass('AcquiaCloudApi\Connector\Client');
+        $property = $reflectionClass->getProperty('requestOptions');
+        $property->setAccessible(true);
+        return $property->getValue($client);
     }
 }

--- a/tests/Connector/ClientTest.php
+++ b/tests/Connector/ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AcquiaCloudApi\Tests\Endpoints;
+namespace AcquiaCloudApi\Tests\Connector;
 
 use AcquiaCloudApi\Tests\CloudApiTestCase;
 use AcquiaCloudApi\Connector\Client;

--- a/tests/Connector/ConnectorTest.php
+++ b/tests/Connector/ConnectorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AcquiaCloudApi\Tests\Endpoints;
+namespace AcquiaCloudApi\Tests\Connector;
 
 use AcquiaCloudApi\Tests\CloudApiTestCase;
 use AcquiaCloudApi\Connector\Connector;

--- a/tests/Connector/FiltersTest.php
+++ b/tests/Connector/FiltersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AcquiaCloudApi\Tests\Endpoints;
+namespace AcquiaCloudApi\Tests\Connector;
 
 use AcquiaCloudApi\Tests\CloudApiTestCase;
 

--- a/tests/Endpoints/AccountTest.php
+++ b/tests/Endpoints/AccountTest.php
@@ -9,26 +9,26 @@ class AccountTest extends CloudApiTestCase
 {
 
     protected $properties = [
-    'id',
-    'uuid',
-    'name',
-    'first_name',
-    'last_name',
-    'last_login_at',
-    'created_at',
-    'mail',
-    'phone',
-    'job_title',
-    'job_function',
-    'company',
-    'country',
-    'state',
-    'timezone',
-    'picture_url',
-    'features',
-    'flags',
-    'metadata',
-    'links'
+        'id',
+        'uuid',
+        'name',
+        'first_name',
+        'last_name',
+        'last_login_at',
+        'created_at',
+        'mail',
+        'phone',
+        'job_title',
+        'job_function',
+        'company',
+        'country',
+        'state',
+        'timezone',
+        'picture_url',
+        'features',
+        'flags',
+        'metadata',
+        'links'
     ];
 
     public function testGetAccount()
@@ -36,7 +36,7 @@ class AccountTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Account/getAccount.json');
         $client = $this->getMockClient($response);
 
-      /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
         $account = new Account($client);
         $result = $account->get();
 

--- a/tests/Endpoints/ApplicationsTest.php
+++ b/tests/Endpoints/ApplicationsTest.php
@@ -38,6 +38,7 @@ class ApplicationsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\ApplicationsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\ApplicationResponse', $record);
@@ -96,6 +97,7 @@ class ApplicationsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\TagsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\TagResponse', $record);

--- a/tests/Endpoints/ApplicationsTest.php
+++ b/tests/Endpoints/ApplicationsTest.php
@@ -9,15 +9,15 @@ class ApplicationsTest extends CloudApiTestCase
 {
 
     protected $properties = [
-    'uuid',
-    'name',
-    'hosting',
-    'subscription',
-    'organization',
-    'type',
-    'flags',
-    'status',
-    'links'
+        'uuid',
+        'name',
+        'hosting',
+        'subscription',
+        'organization',
+        'type',
+        'flags',
+        'status',
+        'links'
     ];
 
     protected $tagProperties = [
@@ -74,8 +74,14 @@ class ApplicationsTest extends CloudApiTestCase
         $application = new Applications($client);
         $result = $application->rename('8ff6c046-ec64-4ce4-bea6-27845ec18600', "My application's new name");
 
-        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $requestOptions = [
+            'json' => [
+                'name' => "My application's new name",
+            ],
+        ];
 
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('Application renamed.', $result->message);
     }
 
@@ -109,8 +115,15 @@ class ApplicationsTest extends CloudApiTestCase
         $application = new Applications($client);
         $result = $application->createTag('8ff6c046-ec64-4ce4-bea6-27845ec18600', "deloitte", "orange");
 
-        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $requestOptions = [
+            'json' => [
+                'name' => 'deloitte',
+                'color' => 'orange',
+            ],
+        ];
 
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('The tag has been added to the application.', $result->message);
     }
 
@@ -124,7 +137,6 @@ class ApplicationsTest extends CloudApiTestCase
         $result = $application->deleteTag('8ff6c046-ec64-4ce4-bea6-27845ec18600', "deloitte");
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('The tag has been removed from the application.', $result->message);
     }
 }

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -91,19 +91,25 @@ class ClientTest extends CloudApiTestCase
         $client->addQuery('limit', '1');
 
         // Set options as an endpoint call would.
-        $options = [
+        $reflectionClass = new \ReflectionClass('AcquiaCloudApi\Connector\Client');
+
+        $requestOptions = [
             'json' => [
                 'source' => 'source',
                 'message' => 'message',
             ],
         ];
 
+        $providerProperty = $reflectionClass->getProperty('requestOptions');
+        $providerProperty->setAccessible(true);
+        $providerProperty->setValue($client, $requestOptions);
+
         // Modify the request to ensure that all of the above get merged correctly.
         // Run modifyOptions twice to ensure that multiple uses of it do not change
         // the end result.
         // @see https://github.com/typhonius/acquia-php-sdk-v2/issues/87
-        $client->modifyOptions($options);
-        $actualOptions = $client->modifyOptions($options);
+        $client->modifyOptions();
+        $actualOptions = $client->modifyOptions();
 
         $version = $client->getVersion();
         $expectedOptions = [

--- a/tests/Endpoints/CodeTest.php
+++ b/tests/Endpoints/CodeTest.php
@@ -24,6 +24,7 @@ class CodeTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\BranchesResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\BranchResponse', $record);

--- a/tests/Endpoints/CodeTest.php
+++ b/tests/Endpoints/CodeTest.php
@@ -43,6 +43,13 @@ class CodeTest extends CloudApiTestCase
         $code = new Code($client);
         $result = $code->switch('8ff6c046-ec64-4ce4-bea6-27845ec18600', 'my-feature-branch');
 
+        $requestOptions = [
+            'json' => [
+                'branch' => 'my-feature-branch',
+            ],
+        ];
+
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('Switching code.', $result->message);
     }
@@ -60,6 +67,14 @@ class CodeTest extends CloudApiTestCase
             'Commit message'
         );
 
+        $requestOptions = [
+            'json' => [
+                'source' => '8ff6c046-ec64-4ce4-bea6-27845ec18600',
+                'message' => 'Commit message',
+            ],
+        ];
+
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('Deploying code.', $result->message);
     }

--- a/tests/Endpoints/ConnectorTest.php
+++ b/tests/Endpoints/ConnectorTest.php
@@ -80,11 +80,13 @@ class ConnectorTest extends CloudApiTestCase
         // Override the provider property set in the constructor.
         $reflectionClass = new \ReflectionClass('AcquiaCloudApi\Connector\Connector');
 
-        $provider = new MockProvider([
+        $provider = new MockProvider(
+            [
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
-        ]);
+            ]
+        );
 
         $providerProperty = $reflectionClass->getProperty('provider');
         $providerProperty->setAccessible(true);

--- a/tests/Endpoints/CronsTest.php
+++ b/tests/Endpoints/CronsTest.php
@@ -35,6 +35,7 @@ class CronsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\CronsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\CronResponse', $record);

--- a/tests/Endpoints/CronsTest.php
+++ b/tests/Endpoints/CronsTest.php
@@ -9,18 +9,18 @@ class CronsTest extends CloudApiTestCase
 {
 
     public $properties = [
-    'id',
-    'server',
-    'command',
-    'minute',
-    'hour',
-    'dayMonth',
-    'month',
-    'dayWeek',
-    'label',
-    'flags',
-    'environment',
-    'links'
+        'id',
+        'server',
+        'command',
+        'minute',
+        'hour',
+        'dayMonth',
+        'month',
+        'dayWeek',
+        'label',
+        'flags',
+        'environment',
+        'links'
     ];
 
     public function testGetAllCrons()
@@ -76,6 +76,16 @@ class CronsTest extends CloudApiTestCase
             'My New Cron'
         );
 
+        $requestOptions = [
+            'json' => [
+                'command' => '/usr/local/bin/drush cc all',
+                'frequency' => '*/30 * * * *',
+                'label' => 'My New Cron',
+                'server_id' => null
+            ],
+        ];
+
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('Creating a new cron.', $result->message);
     }
@@ -95,6 +105,16 @@ class CronsTest extends CloudApiTestCase
             'My New Cron'
         );
 
+        $requestOptions = [
+            'json' => [
+                'command' => '/usr/local/bin/drush cc all',
+                'frequency' => '*/30 * * * *',
+                'label' => 'My New Cron',
+                'server_id' => null
+            ],
+        ];
+
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('Updating cron.', $result->message);
     }

--- a/tests/Endpoints/DatabaseBackupsTest.php
+++ b/tests/Endpoints/DatabaseBackupsTest.php
@@ -30,7 +30,6 @@ class DatabaseBackupsTest extends CloudApiTestCase
         $result = $databaseBackup->create('185f07c7-9c4f-407b-8968-67892ebcb38a', 'db_name');
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Creating the backup.', $result->message);
     }
 
@@ -82,7 +81,6 @@ class DatabaseBackupsTest extends CloudApiTestCase
         $result = $databaseBackup->restore('24-a47ac10b-58cc-4372-a567-0e02b2c3d470', 'db_name', 12);
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Restoring the database backup.', $result->message);
     }
 
@@ -112,7 +110,6 @@ class DatabaseBackupsTest extends CloudApiTestCase
         $result = $databaseBackup->delete('185f07c7-9c4f-407b-8968-67892ebcb38a', 'db_name', 1234);
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Deleting the database backup.', $result->message);
     }
 }

--- a/tests/Endpoints/DatabaseBackupsTest.php
+++ b/tests/Endpoints/DatabaseBackupsTest.php
@@ -44,6 +44,7 @@ class DatabaseBackupsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\BackupsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\BackupResponse', $record);

--- a/tests/Endpoints/DatabasesTest.php
+++ b/tests/Endpoints/DatabasesTest.php
@@ -47,6 +47,14 @@ class DatabasesTest extends CloudApiTestCase
             '14-0c7e79ab-1c4a-424e-8446-76ae8be7e851'
         );
 
+        $requestOptions = [
+            'json' => [
+                'name' => 'db_name',
+                'source' => '24-a47ac10b-58cc-4372-a567-0e02b2c3d470',
+            ],
+        ];
+
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('The database is being copied', $result->message);
     }
@@ -60,6 +68,13 @@ class DatabasesTest extends CloudApiTestCase
         $databases = new Databases($client);
         $result = $databases->create('8ff6c046-ec64-4ce4-bea6-27845ec18600', 'db_name');
 
+        $requestOptions = [
+            'json' => [
+                'name' => 'db_name',
+            ],
+        ];
+
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('The database is being created.', $result->message);
     }
@@ -74,7 +89,6 @@ class DatabasesTest extends CloudApiTestCase
         $result = $databases->delete('8ff6c046-ec64-4ce4-bea6-27845ec18600', 'db_name');
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('The database is being deleted.', $result->message);
     }
 
@@ -88,7 +102,6 @@ class DatabasesTest extends CloudApiTestCase
         $result = $databases->truncate('da1c0a8e-ff69-45db-88fc-acd6d2affbb7', 'drupal8');
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('The database is being erased.', $result->message);
     }
 }

--- a/tests/Endpoints/DatabasesTest.php
+++ b/tests/Endpoints/DatabasesTest.php
@@ -24,6 +24,7 @@ class DatabasesTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\DatabasesResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\DatabaseResponse', $record);

--- a/tests/Endpoints/DomainsTest.php
+++ b/tests/Endpoints/DomainsTest.php
@@ -34,6 +34,7 @@ class DomainsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\DomainsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\DomainResponse', $record);
@@ -122,6 +123,7 @@ class DomainsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\MetricsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\MetricResponse', $record);

--- a/tests/Endpoints/DomainsTest.php
+++ b/tests/Endpoints/DomainsTest.php
@@ -9,9 +9,9 @@ class DomainsTest extends CloudApiTestCase
 {
 
     public $properties = [
-    'hostname',
-    'flags',
-    'environment',
+        'hostname',
+        'flags',
+        'environment',
     ];
 
     public $metricsProperties = [
@@ -70,6 +70,13 @@ class DomainsTest extends CloudApiTestCase
         $domain = new Domains($client);
         $result = $domain->create('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851', 'new-domain.com');
 
+        $requestOptions = [
+            'json' => [
+                'hostname' => 'new-domain.com',
+            ],
+        ];
+
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals("Adding domain example.com", $result->message);
     }

--- a/tests/Endpoints/EnvironmentsTest.php
+++ b/tests/Endpoints/EnvironmentsTest.php
@@ -9,19 +9,19 @@ class EnvironmentsTest extends CloudApiTestCase
 {
 
     public $properties = [
-    'uuid',
-    'label',
-    'name',
-    'domains',
-    'sshUrl',
-    'ips',
-    'region',
-    'status',
-    'type',
-    'vcs',
-    'flags',
-    'configuration',
-    'links'
+        'uuid',
+        'label',
+        'name',
+        'domains',
+        'sshUrl',
+        'ips',
+        'region',
+        'status',
+        'type',
+        'vcs',
+        'flags',
+        'configuration',
+        'links'
     ];
 
     public function testGetEnvironments()
@@ -74,9 +74,15 @@ class EnvironmentsTest extends CloudApiTestCase
         $environment = new Environments($client);
         $result = $environment->update('24-a47ac10b-58cc-4372-a567-0e02b2c3d470', ['version' => '7.2']);
 
-         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $requestOptions = [
+            'json' => [
+                'version' => '7.2',
+            ],
+        ];
 
-         $this->assertEquals('The environment configuration is being updated.', $result->message);
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $this->assertEquals('The environment configuration is being updated.', $result->message);
     }
 
     public function testRenameEnvironment()
@@ -89,8 +95,14 @@ class EnvironmentsTest extends CloudApiTestCase
         $environment = new Environments($client);
         $result = $environment->rename('24-a47ac10b-58cc-4372-a567-0e02b2c3d470', 'Alpha');
 
-        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $requestOptions = [
+            'json' => [
+                'label' => 'Alpha',
+            ],
+        ];
 
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('Changing environment label.', $result->message);
     }
 
@@ -112,8 +124,19 @@ class EnvironmentsTest extends CloudApiTestCase
             ]
         );
 
-        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $requestOptions = [
+            'json' => [
+                'label' => 'CD label',
+                'branch' => 'my-feature-branch',
+                'databases' => [
+                    "database1",
+                    "database2"
+                ],
+            ],
+        ];
 
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('Adding an environment.', $result->message);
     }
 
@@ -128,7 +151,6 @@ class EnvironmentsTest extends CloudApiTestCase
         $result = $environment->delete('24-a47ac10b-58cc-4372-a567-0e02b2c3d470');
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('The environment is being deleted.', $result->message);
     }
 }

--- a/tests/Endpoints/EnvironmentsTest.php
+++ b/tests/Endpoints/EnvironmentsTest.php
@@ -36,6 +36,7 @@ class EnvironmentsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\EnvironmentsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\EnvironmentResponse', $record);

--- a/tests/Endpoints/FilesTest.php
+++ b/tests/Endpoints/FilesTest.php
@@ -19,6 +19,14 @@ class FilesTest extends CloudApiTestCase
             '8ff6c046-ec64-4ce4-bea6-27845ec18600',
             '14-0c7e79ab-1c4a-424e-8446-76ae8be7e851'
         );
+
+        $requestOptions = [
+            'json' => [
+                'source' => '8ff6c046-ec64-4ce4-bea6-27845ec18600',
+            ],
+        ];
+
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('Copying files.', $result->message);
     }

--- a/tests/Endpoints/IdentityProviderTest.php
+++ b/tests/Endpoints/IdentityProviderTest.php
@@ -9,13 +9,13 @@ class IdentityProviderTest extends CloudApiTestCase
 {
 
     public $properties = [
-    'uuid',
-    'label',
-    'idp_entity_id',
-    'sso_url',
-    'certificate',
-    'status',
-    'links',
+        'uuid',
+        'label',
+        'idp_entity_id',
+        'sso_url',
+        'certificate',
+        'status',
+        'links',
     ];
 
     public function testGetLogForwardingDestinations()
@@ -114,8 +114,17 @@ class IdentityProviderTest extends CloudApiTestCase
             "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
         );
 
-        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $requestOptions = [
+            'json' => [
+                'label' => 'Test IDP',
+                'entity_id' => 'entity-id',
+                'sso_url' => 'https://idp.example.com',
+                'certificate' => "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----",
+            ],
+        ];
 
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('Identity Provider has been updated.', $result->message);
     }
 }

--- a/tests/Endpoints/IdentityProviderTest.php
+++ b/tests/Endpoints/IdentityProviderTest.php
@@ -30,6 +30,7 @@ class IdentityProviderTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\IdentityProvidersResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\IdentityProviderResponse', $record);
@@ -67,7 +68,6 @@ class IdentityProviderTest extends CloudApiTestCase
         $result = $idp->delete('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851');
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Identity provider has been deleted.', $result->message);
     }
 
@@ -81,7 +81,6 @@ class IdentityProviderTest extends CloudApiTestCase
         $result = $idp->enable('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851');
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Identity Provider has been enabled.', $result->message);
     }
 
@@ -95,7 +94,6 @@ class IdentityProviderTest extends CloudApiTestCase
         $result = $idp->disable('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851');
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Identity Provider has been disabled.', $result->message);
     }
 

--- a/tests/Endpoints/IdesTest.php
+++ b/tests/Endpoints/IdesTest.php
@@ -9,10 +9,10 @@ class IdesTest extends CloudApiTestCase
 {
 
     public $properties = [
-    'uuid',
-    'label',
-    'links',
-    'owner',
+        'uuid',
+        'label',
+        'links',
+        'owner',
     ];
 
     public function testGetAllIdes()
@@ -66,8 +66,14 @@ class IdesTest extends CloudApiTestCase
             'My new IDE'
         );
 
-        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $requestOptions = [
+            'json' => [
+                'label' => 'My new IDE',
+            ],
+        ];
 
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('The remote IDE is being created.', $result->message);
     }
 
@@ -81,7 +87,6 @@ class IdesTest extends CloudApiTestCase
         $result = $ide->delete('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851');
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('The remote IDE is being deleted.', $result->message);
     }
 }

--- a/tests/Endpoints/IdesTest.php
+++ b/tests/Endpoints/IdesTest.php
@@ -27,6 +27,7 @@ class IdesTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\IdesResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\IdeResponse', $record);

--- a/tests/Endpoints/InsightsTest.php
+++ b/tests/Endpoints/InsightsTest.php
@@ -9,16 +9,16 @@ class InsightsTest extends CloudApiTestCase
 {
 
     public $properties = [
-    'uuid',
-    'label',
-    'hostname',
-    'status',
-    'updatedAt',
-    'lastConnectedAt',
-    'scores',
-    'counts',
-    'flags',
-    'links'
+        'uuid',
+        'label',
+        'hostname',
+        'status',
+        'updatedAt',
+        'lastConnectedAt',
+        'scores',
+        'counts',
+        'flags',
+        'links'
     ];
 
     public $alertProperties = [
@@ -57,7 +57,7 @@ class InsightsTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Insights/getAllInsights.json');
         $client = $this->getMockClient($response);
 
-      /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
         $insights = new Insights($client);
         $result = $insights->getAll('8ff6c046-ec64-4ce4-bea6-27845ec18600');
 
@@ -79,7 +79,7 @@ class InsightsTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Insights/getEnvironment.json');
         $client = $this->getMockClient($response);
 
-      /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
         $insights = new Insights($client);
         $result = $insights->getEnvironment('8ff6c046-ec64-4ce4-bea6-27845ec18600');
 
@@ -116,7 +116,7 @@ class InsightsTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Insights/getAllAlerts.json');
         $client = $this->getMockClient($response);
 
-      /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
         $insights = new Insights($client);
         $result = $insights->getAllAlerts('8ff6c046-ec64-4ce4-bea6-27845ec18600');
 
@@ -218,7 +218,7 @@ class InsightsTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Insights/getModules.json');
         $client = $this->getMockClient($response);
 
-      /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
         $insights = new Insights($client);
         $result = $insights->getModules('8ff6c046-ec64-4ce4-bea6-27845ec18600');
 

--- a/tests/Endpoints/InsightsTest.php
+++ b/tests/Endpoints/InsightsTest.php
@@ -63,6 +63,7 @@ class InsightsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\InsightsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\InsightResponse', $record);
@@ -85,6 +86,7 @@ class InsightsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\InsightsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\InsightResponse', $record);
@@ -108,6 +110,15 @@ class InsightsTest extends CloudApiTestCase
         foreach ($this->properties as $property) {
             $this->assertObjectHasAttribute($property, $result);
         }
+
+        // Check that insight counts consist of InsightCountResponse.
+        $this->assertNotEmpty($result->counts);
+        $this->assertObjectHasAttribute('best_practices', $result->counts);
+        $this->assertObjectHasAttribute('security', $result->counts);
+        $this->assertObjectHasAttribute('performance', $result->counts);
+        foreach ($result->counts as $name => $response) {
+            $this->assertInstanceOf('\AcquiaCloudApi\Response\InsightCountResponse', $response);
+        }
     }
 
     public function testGetAllAlerts()
@@ -122,6 +133,7 @@ class InsightsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\InsightAlertsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\InsightAlertResponse', $record);
@@ -163,7 +175,6 @@ class InsightsTest extends CloudApiTestCase
         );
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Alert ignored.', $result->message);
     }
 
@@ -180,7 +191,6 @@ class InsightsTest extends CloudApiTestCase
         );
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Alert restored.', $result->message);
     }
 
@@ -194,7 +204,6 @@ class InsightsTest extends CloudApiTestCase
         $result = $insights->revoke('8ff6c046-ec64-4ce4-bea6-27845ec18600');
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Site revoked from submitting Insight score data.', $result->message);
     }
 
@@ -208,7 +217,6 @@ class InsightsTest extends CloudApiTestCase
         $result = $insights->unrevoke('8ff6c046-ec64-4ce4-bea6-27845ec18600');
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Site un-revoked.', $result->message);
     }
 
@@ -224,6 +232,7 @@ class InsightsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\InsightModulesResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\InsightModuleResponse', $record);

--- a/tests/Endpoints/LiveDevTest.php
+++ b/tests/Endpoints/LiveDevTest.php
@@ -31,8 +31,14 @@ class LiveDevTest extends CloudApiTestCase
         $environment = new Environments($client);
         $result = $environment->disableLiveDev('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851');
 
-        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $requestOptions = [
+            'json' => [
+                'discard' => 1,
+            ],
+        ];
 
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('Live Dev is being disabled.', $result->message);
     }
 }

--- a/tests/Endpoints/LogForwardingTest.php
+++ b/tests/Endpoints/LogForwardingTest.php
@@ -9,16 +9,16 @@ class LogForwardingTest extends CloudApiTestCase
 {
 
     public $properties = [
-    'uuid',
-    'label',
-    'address',
-    'consumer',
-    'credentials',
-    'sources',
-    'status',
-    'flags',
-    'health',
-    'environment'
+        'uuid',
+        'label',
+        'address',
+        'consumer',
+        'credentials',
+        'sources',
+        'status',
+        'flags',
+        'health',
+        'environment'
     ];
 
     public function testGetLogForwardingDestinations()
@@ -77,8 +77,17 @@ class LogForwardingTest extends CloudApiTestCase
             'example.com:1234'
         );
 
+        $requestOptions = [
+            'json' => [
+                'label' => 'Test destination',
+                'sources' => ["apache-access", "apache-error"],
+                'consumer' => 'syslog',
+                'credentials' => ["certificate" => "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"],
+                'address' => 'example.com:1234'
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Log forwarding destination for the environment has been created.', $result->message);
     }
 
@@ -141,8 +150,17 @@ class LogForwardingTest extends CloudApiTestCase
             'example.com:1234'
         );
 
+        $requestOptions = [
+            'json' => [
+                'label' => 'Test destination',
+                'sources' => ["apache-access", "apache-error"],
+                'consumer' => 'syslog',
+                'credentials' => ["certificate" => "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"],
+                'address' => 'example.com:1234'
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Log forwarding destination has been updated.', $result->message);
     }
 }

--- a/tests/Endpoints/LogForwardingTest.php
+++ b/tests/Endpoints/LogForwardingTest.php
@@ -33,6 +33,7 @@ class LogForwardingTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\LogForwardingDestinationsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\LogForwardingDestinationResponse', $record);
@@ -101,7 +102,6 @@ class LogForwardingTest extends CloudApiTestCase
         $result = $logForwarding->delete('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851', 14);
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Log forwarding destination has been deleted.', $result->message);
     }
 
@@ -115,7 +115,6 @@ class LogForwardingTest extends CloudApiTestCase
         $result = $logForwarding->enable('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851', 2);
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Log forwarding destination has been enabled.', $result->message);
     }
 
@@ -129,7 +128,6 @@ class LogForwardingTest extends CloudApiTestCase
         $result = $logForwarding->disable('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851', 2);
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Log forwarding destination has been disabled.', $result->message);
     }
 

--- a/tests/Endpoints/LogsTest.php
+++ b/tests/Endpoints/LogsTest.php
@@ -32,6 +32,7 @@ class LogsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\LogsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\LogResponse', $record);

--- a/tests/Endpoints/LogsTest.php
+++ b/tests/Endpoints/LogsTest.php
@@ -9,15 +9,15 @@ class LogsTest extends CloudApiTestCase
 {
 
     public $properties = [
-    'type',
-    'label',
-    'flags',
-    'links'
+        'type',
+        'label',
+        'flags',
+        'links'
     ];
 
     public $logstreamProperties = [
-    'logstream',
-    'links'
+        'logstream',
+        'links'
     ];
 
     public function testGetLogs()

--- a/tests/Endpoints/MembersTest.php
+++ b/tests/Endpoints/MembersTest.php
@@ -30,6 +30,7 @@ class MembersTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\MembersResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\MemberResponse', $record);
@@ -71,6 +72,7 @@ class MembersTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\MembersResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\MemberResponse', $record);
@@ -114,7 +116,6 @@ class MembersTest extends CloudApiTestCase
         );
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals("Organization member removed.", $result->message);
     }
 }

--- a/tests/Endpoints/MetricsTest.php
+++ b/tests/Endpoints/MetricsTest.php
@@ -9,11 +9,11 @@ class MetricsTest extends CloudApiTestCase
 {
 
     protected $properties = [
-    'metric',
-    'datapoints',
-    'last_data_at',
-    'metadata',
-    'links'
+        'metric',
+        'datapoints',
+        'last_data_at',
+        'metadata',
+        'links'
     ];
 
     public function testGetAggregateData()
@@ -21,7 +21,7 @@ class MetricsTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Metrics/getAggregateData.json');
         $client = $this->getMockClient($response);
 
-      /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
         $account = new Metrics($client);
         $result = $account->getAggregateData('8ff6c046-ec64-4ce4-bea6-27845ec18600');
 

--- a/tests/Endpoints/MetricsTest.php
+++ b/tests/Endpoints/MetricsTest.php
@@ -27,6 +27,7 @@ class MetricsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\MetricsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\MetricResponse', $record);
@@ -62,6 +63,7 @@ class MetricsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\MetricsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\MetricResponse', $record);
@@ -81,6 +83,7 @@ class MetricsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\MetricsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\MetricResponse', $record);
@@ -100,6 +103,7 @@ class MetricsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\MetricsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\MetricResponse', $record);
@@ -119,6 +123,7 @@ class MetricsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\MetricsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\MetricResponse', $record);

--- a/tests/Endpoints/NotificationTest.php
+++ b/tests/Endpoints/NotificationTest.php
@@ -48,6 +48,8 @@ class NotificationTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\NotificationsResponse', $result);
         $this->assertInstanceOf('\ArrayObject', $result);
+        $this->assertNotEmpty($result);
+
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\NotificationResponse', $record);
             foreach ($this->properties as $property) {

--- a/tests/Endpoints/NotificationTest.php
+++ b/tests/Endpoints/NotificationTest.php
@@ -10,16 +10,16 @@ use AcquiaCloudApi\Endpoints\Applications;
 class NotificationTest extends CloudApiTestCase
 {
     protected $properties = [
-    'uuid',
-    'event',
-    'label',
-    'description',
-    'created_at',
-    'completed_at',
-    'status',
-    'progress',
-    'context',
-    'links'
+        'uuid',
+        'event',
+        'label',
+        'description',
+        'created_at',
+        'completed_at',
+        'status',
+        'progress',
+        'context',
+        'links'
     ];
 
     public function testGetNotification()

--- a/tests/Endpoints/OrganizationsTest.php
+++ b/tests/Endpoints/OrganizationsTest.php
@@ -87,8 +87,13 @@ class OrganizationsTest extends CloudApiTestCase
         $organization = new Organizations($client);
         $result = $organization->inviteAdmin('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851', 'user@example.com');
 
+        $requestOptions = [
+            'json' => [
+                'email' => 'user@example.com',
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Invited organization administrator.', $result->message);
     }
 
@@ -181,6 +186,12 @@ class OrganizationsTest extends CloudApiTestCase
             '82cff7ec-2f09-11e9-b210-d663bd873d93'
         );
 
+        $requestOptions = [
+            'json' => [
+                'user_uuid' => '82cff7ec-2f09-11e9-b210-d663bd873d93',
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals("Changed organization owner.", $result->message);
     }

--- a/tests/Endpoints/OrganizationsTest.php
+++ b/tests/Endpoints/OrganizationsTest.php
@@ -68,6 +68,7 @@ class OrganizationsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OrganizationsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\OrganizationResponse', $record);
@@ -108,6 +109,7 @@ class OrganizationsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\ApplicationsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\ApplicationResponse', $record);
@@ -129,6 +131,7 @@ class OrganizationsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\TeamsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\TeamResponse', $record);
@@ -151,6 +154,7 @@ class OrganizationsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\InvitationsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\InvitationResponse', $record);

--- a/tests/Endpoints/PermissionsTest.php
+++ b/tests/Endpoints/PermissionsTest.php
@@ -27,6 +27,7 @@ class PermissionsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\PermissionsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\PermissionResponse', $record);

--- a/tests/Endpoints/PermissionsTest.php
+++ b/tests/Endpoints/PermissionsTest.php
@@ -9,10 +9,10 @@ class PermissionsTest extends CloudApiTestCase
 {
 
     public $properties = [
-    'name',
-    'label',
-    'description',
-    'group_label',
+        'name',
+        'label',
+        'description',
+        'group_label',
     ];
 
     public function testGetAllPermissions()

--- a/tests/Endpoints/ProductionModeTest.php
+++ b/tests/Endpoints/ProductionModeTest.php
@@ -18,7 +18,6 @@ class ProductionModeTest extends CloudApiTestCase
         $result = $environment->enableProductionMode('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851');
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Production mode has been enabled for this environment.', $result->message);
     }
 
@@ -32,7 +31,6 @@ class ProductionModeTest extends CloudApiTestCase
         $result = $environment->disableProductionMode('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851');
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Production mode has been disabled for this environment.', $result->message);
     }
 }

--- a/tests/Endpoints/RolesTest.php
+++ b/tests/Endpoints/RolesTest.php
@@ -45,6 +45,7 @@ class RolesTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\RolesResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\RoleResponse', $record);

--- a/tests/Endpoints/RolesTest.php
+++ b/tests/Endpoints/RolesTest.php
@@ -10,11 +10,11 @@ class RolesTest extends CloudApiTestCase
 {
 
     public $properties = [
-    'uuid',
-    'name',
-    'description',
-    'last_edited',
-    'permissions',
+        'uuid',
+        'name',
+        'description',
+        'last_edited',
+        'permissions',
     ];
 
     public function testGetRole()
@@ -60,7 +60,7 @@ class RolesTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Roles/createRole.json');
         $client = $this->getMockClient($response);
 
-      /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
         $roles = new Roles($client);
         $result = $roles->create(
             '8ff6c046-ec64-4ce4-bea6-27845ec18600',
@@ -69,6 +69,14 @@ class RolesTest extends CloudApiTestCase
             'My new role description'
         );
 
+        $requestOptions = [
+            'json' => [
+                'name' => 'My new role',
+                'permissions' => ['access cloud api', 'pull from prod'],
+                'description' => 'My new role description',
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('Role created.', $result->message);
     }
@@ -95,6 +103,12 @@ class RolesTest extends CloudApiTestCase
         $role = new Roles($client);
         $result = $role->update('r47ac10b-58cc-4372-a567-0e02b2c3d470', ['pull from prod']);
 
+        $requestOptions = [
+            'json' => [
+                'permissions' => ['pull from prod'],
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals('Updating role.', $result->message);
     }

--- a/tests/Endpoints/ServersTest.php
+++ b/tests/Endpoints/ServersTest.php
@@ -9,16 +9,16 @@ class ServersTest extends CloudApiTestCase
 {
 
     public $properties = [
-    'id',
-    'name',
-    'hostname',
-    'ip',
-    'status',
-    'region',
-    'roles',
-    'amiType',
-    'configuration',
-    'flags',
+        'id',
+        'name',
+        'hostname',
+        'ip',
+        'status',
+        'region',
+        'roles',
+        'amiType',
+        'configuration',
+        'flags',
     ];
 
     public function testGetServers()
@@ -74,7 +74,6 @@ class ServersTest extends CloudApiTestCase
         );
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('The server configuration is being updated.', $result->message);
     }
 }

--- a/tests/Endpoints/ServersTest.php
+++ b/tests/Endpoints/ServersTest.php
@@ -33,6 +33,7 @@ class ServersTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\ServersResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\ServerResponse', $record);

--- a/tests/Endpoints/SslCertificatesTest.php
+++ b/tests/Endpoints/SslCertificatesTest.php
@@ -74,7 +74,6 @@ class SslCertificatesTest extends CloudApiTestCase
             '-----BEGIN RSA PRIVATE KEY-----secret....-----END RSA PRIVATE KEY-----',
             '-----BEGIN CERTIFICATE-----123abc....-----END CERTIFICATE-----',
             123,
-            false
         );
 
         $requestOptions = [
@@ -85,6 +84,40 @@ class SslCertificatesTest extends CloudApiTestCase
                 'ca_certificates' => '-----BEGIN CERTIFICATE-----123abc....-----END CERTIFICATE-----',
                 'csr_id' => 123,
                 'legacy' => false
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $this->assertEquals('Installing the certificate.', $result->message);
+    }
+
+    public function testCreateLegacySslCertificate()
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/SslCertificates/createSslCertificate.json');
+        $client = $this->getMockClient($response);
+
+        /**
+         * @var \AcquiaCloudApi\CloudApi\ClientInterface $client
+         */
+        $certificate = new SslCertificates($client);
+        $result = $certificate->create(
+            '14-0c7e79ab-1c4a-424e-8446-76ae8be7e851',
+            'My New Cert',
+            '-----BEGIN CERTIFICATE-----abc123....-----END CERTIFICATE-----',
+            '-----BEGIN RSA PRIVATE KEY-----secret....-----END RSA PRIVATE KEY-----',
+            '-----BEGIN CERTIFICATE-----123abc....-----END CERTIFICATE-----',
+            123,
+            true
+        );
+
+        $requestOptions = [
+            'json' => [
+                'label' => 'My New Cert',
+                'certificate' => '-----BEGIN CERTIFICATE-----abc123....-----END CERTIFICATE-----',
+                'private_key' => '-----BEGIN RSA PRIVATE KEY-----secret....-----END RSA PRIVATE KEY-----',
+                'ca_certificates' => '-----BEGIN CERTIFICATE-----123abc....-----END CERTIFICATE-----',
+                'csr_id' => 123,
+                'legacy' => true
             ],
         ];
         $this->assertEquals($requestOptions, $this->getRequestOptions($client));

--- a/tests/Endpoints/SslCertificatesTest.php
+++ b/tests/Endpoints/SslCertificatesTest.php
@@ -9,16 +9,16 @@ class SslCertificatesTest extends CloudApiTestCase
 {
 
     public $properties = [
-    'id',
-    'label',
-    'certificate',
-    'private_key',
-    'ca',
-    'flags',
-    'expires_at',
-    'domains',
-    'environment',
-    'links'
+        'id',
+        'label',
+        'certificate',
+        'private_key',
+        'ca',
+        'flags',
+        'expires_at',
+        'domains',
+        'environment',
+        'links'
     ];
 
     public function testGetCertificates()
@@ -77,8 +77,18 @@ class SslCertificatesTest extends CloudApiTestCase
             false
         );
 
+        $requestOptions = [
+            'json' => [
+                'label' => 'My New Cert',
+                'certificate' => '-----BEGIN CERTIFICATE-----abc123....-----END CERTIFICATE-----',
+                'private_key' => '-----BEGIN RSA PRIVATE KEY-----secret....-----END RSA PRIVATE KEY-----',
+                'ca_certificates' => '-----BEGIN CERTIFICATE-----123abc....-----END CERTIFICATE-----',
+                'csr_id' => 123,
+                'legacy' => false
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Installing the certificate.', $result->message);
     }
 
@@ -92,7 +102,6 @@ class SslCertificatesTest extends CloudApiTestCase
         $result = $certificate->delete('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851', 14);
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Deleting the certificate.', $result->message);
     }
 
@@ -106,7 +115,6 @@ class SslCertificatesTest extends CloudApiTestCase
         $result = $certificate->enable('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851', 2);
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Activating the certificate.', $result->message);
     }
 
@@ -120,7 +128,6 @@ class SslCertificatesTest extends CloudApiTestCase
         $result = $certificate->disable('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851', 2);
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Deactivating the certificate.', $result->message);
     }
 }

--- a/tests/Endpoints/SslCertificatesTest.php
+++ b/tests/Endpoints/SslCertificatesTest.php
@@ -33,6 +33,7 @@ class SslCertificatesTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\SslCertificatesResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\SslCertificateResponse', $record);

--- a/tests/Endpoints/TeamsTest.php
+++ b/tests/Endpoints/TeamsTest.php
@@ -42,6 +42,7 @@ class TeamsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\TeamsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\TeamResponse', $record);
@@ -160,6 +161,7 @@ class TeamsTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\ApplicationsResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\ApplicationResponse', $record);

--- a/tests/Endpoints/TeamsTest.php
+++ b/tests/Endpoints/TeamsTest.php
@@ -65,8 +65,14 @@ class TeamsTest extends CloudApiTestCase
             ['access permissions', 'access servers']
         );
 
+        $requestOptions = [
+            'json' => [
+                'email' => 'hello@example.com',
+                'roles' => ['access permissions', 'access servers'],
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals("Invited team member.", $result->message);
     }
 
@@ -79,8 +85,13 @@ class TeamsTest extends CloudApiTestCase
         $organization = new Teams($client);
         $result = $organization->create('8ff6c046-ec64-4ce4-bea6-27845ec18600', 'Mega Team');
 
+        $requestOptions = [
+            'json' => [
+                'name' => 'Mega Team',
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals("Team created.", $result->message);
     }
 
@@ -93,8 +104,13 @@ class TeamsTest extends CloudApiTestCase
         $team = new Teams($client);
         $result = $team->rename('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851', 'My Cool Application');
 
+        $requestOptions = [
+            'json' => [
+                'name' => 'My Cool Application',
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals("Team renamed.", $result->message);
     }
 
@@ -108,7 +124,6 @@ class TeamsTest extends CloudApiTestCase
         $result = $team->delete('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851');
 
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals("Removed team.", $result->message);
     }
 
@@ -124,8 +139,13 @@ class TeamsTest extends CloudApiTestCase
             '14-0c7e79ab-1c4a-424e-8446-76ae8be7e851'
         );
 
+        $requestOptions = [
+            'json' => [
+                'uuid' => '14-0c7e79ab-1c4a-424e-8446-76ae8be7e851',
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('Added application to team.', $result->message);
     }
 

--- a/tests/Endpoints/VariablesTest.php
+++ b/tests/Endpoints/VariablesTest.php
@@ -25,6 +25,7 @@ class VariablesTest extends CloudApiTestCase
 
         $this->assertInstanceOf('\ArrayObject', $result);
         $this->assertInstanceOf('\AcquiaCloudApi\Response\VariablesResponse', $result);
+        $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
             $this->assertInstanceOf('\AcquiaCloudApi\Response\VariableResponse', $record);

--- a/tests/Endpoints/VariablesTest.php
+++ b/tests/Endpoints/VariablesTest.php
@@ -19,6 +19,7 @@ class VariablesTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Variables/getAllVariables.json');
         $client = $this->getMockClient($response);
 
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
         $variable = new Variables($client);
         $result = $variable->getAll('24-569086da-2b1f-11e9-b210-d663bd873d93');
 
@@ -39,6 +40,7 @@ class VariablesTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Variables/getVariable.json');
         $client = $this->getMockClient($response);
 
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
         $variable = new Variables($client);
         $result = $variable->get('24-734b7960-2b1f-11e9-b210-d663bd873d93', 'variable_one');
 
@@ -56,9 +58,17 @@ class VariablesTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Variables/createVariable.json');
         $client = $this->getMockClient($response);
 
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
         $variable = new Variables($client);
         $result = $variable->create('123-c7056b9e-0fb7-44e9-a434-426a404211c1', 'test_variable', 'test_value');
 
+        $requestOptions = [
+            'json' => [
+                'name' => 'test_variable',
+                'value' => 'test_value',
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
         $this->assertEquals("The environment variable is being added.", $result->message);
     }
@@ -68,6 +78,7 @@ class VariablesTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Variables/updateVariable.json');
         $client = $this->getMockClient($response);
 
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
         $variable = new Variables($client);
         $result = $variable->update(
             '24-734b7960-2b1f-11e9-b210-d663bd873d93',
@@ -75,8 +86,14 @@ class VariablesTest extends CloudApiTestCase
             'value'
         );
 
+        $requestOptions = [
+            'json' => [
+                'name' => 'name',
+                'value' => 'value',
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
-
         $this->assertEquals('The environment variable is being updated.', $result->message);
     }
 
@@ -85,6 +102,7 @@ class VariablesTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Variables/deleteVariable.json');
         $client = $this->getMockClient($response);
 
+        /** @var \AcquiaCloudApi\CloudApi\ClientInterface $client */
         $variable = new Variables($client);
         $result = $variable->delete('12-d314739e-296f-11e9-b210-d663bd873d93', 'EXAMPLE_VARIABLE_NAME');
 

--- a/tests/Endpoints/VarnishTest.php
+++ b/tests/Endpoints/VarnishTest.php
@@ -20,6 +20,12 @@ class VarnishTest extends CloudApiTestCase
             ['example.com', 'www.example.com']
         );
 
+        $requestOptions = [
+            'json' => [
+                'domains' => ['example.com', 'www.example.com'],
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
         $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
 
         $this->assertEquals('Varnish is being cleared for the selected domains.', $result->message);

--- a/tests/Exception/ErrorTest.php
+++ b/tests/Exception/ErrorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AcquiaCloudApi\Tests\Endpoints;
+namespace AcquiaCloudApi\Tests\Exception;
 
 use AcquiaCloudApi\Tests\CloudApiTestCase;
 use GuzzleHttp\Exception\BadResponseException;
@@ -89,5 +89,14 @@ AcquiaCloudApi\Exception\ApiErrorException: [forbidden]: You do not have permiss
 EOM;
         $this->assertEquals($exception->__toString(), $errorMessage);
         $this->assertEquals($object, $exception->getResponseBody());
+        $this->assertEquals(0, $exception->getCode());
+
+        $exception = new ApiErrorException($object, null, 403);
+        $errorMessage = <<< EOM
+AcquiaCloudApi\Exception\ApiErrorException: [forbidden]: You do not have permission to view applications.\n
+EOM;
+        $this->assertEquals($exception->__toString(), $errorMessage);
+        $this->assertEquals($object, $exception->getResponseBody());
+        $this->assertEquals(403, $exception->getCode());
     }
 }

--- a/tests/Exception/ErrorTest.php
+++ b/tests/Exception/ErrorTest.php
@@ -91,7 +91,7 @@ EOM;
         $this->assertEquals($object, $exception->getResponseBody());
         $this->assertEquals(0, $exception->getCode());
 
-        $exception = new ApiErrorException($object, null, 403);
+        $exception = new ApiErrorException($object, "", 403);
         $errorMessage = <<< EOM
 AcquiaCloudApi\Exception\ApiErrorException: [forbidden]: You do not have permission to view applications.\n
 EOM;


### PR DESCRIPTION
Allows request options to be accessed in tests to proof the library from mistakes involving parameters passed as options in API calls. We're also doing this to allow mutation testing with Infection (https://infection.github.io/).