### PR TITLE
Moves VERSION into a const as a file causes issues for eloquent mocks…

### DIFF
--- a/src/Connector/Client.php
+++ b/src/Connector/Client.php
@@ -65,11 +65,7 @@ class Client implements ClientInterface
      */
     public function getVersion(): string
     {
-        if ($file = @file_get_contents(dirname(dirname(__DIR__)) . '/VERSION')) {
-            return trim($file);
-        } else {
-            throw new \Exception('No VERSION file');
-        }
+        return self::VERSION;
     }
 
     /**

--- a/src/Connector/ClientInterface.php
+++ b/src/Connector/ClientInterface.php
@@ -13,6 +13,10 @@ use AcquiaCloudApi\Exception\ApiErrorException;
  */
 interface ClientInterface
 {
+    /**
+     * @var string VERSION
+     */
+    public const VERSION = '2.0.16-dev';
 
     /**
      * Returns the current version of the library.

--- a/tests/Connector/ClientTest.php
+++ b/tests/Connector/ClientTest.php
@@ -131,28 +131,13 @@ class ClientTest extends CloudApiTestCase
 
     public function testVersion(): void
     {
-        $versionFile = sprintf('%s/VERSION', dirname(dirname(__DIR__)));
-        $version = trim(file_get_contents($versionFile));
+        $reflectionClass = new \ReflectionClass('AcquiaCloudApi\Connector\Client');
+        $constants = $reflectionClass->getConstants();
+        $reflectionVersion = $constants['VERSION'];
 
         $client = $this->getMockClient();
-        $actualValue = $client->getVersion();
+        $methodVersion = $client->getVersion();
 
-        $this->assertEquals($version, $actualValue);
-    }
-
-    public function testMissingVersion(): void
-    {
-        $versionFile = sprintf('%s/VERSION', dirname(dirname(__DIR__)));
-        $versionFileBak = sprintf('%s.bak', $versionFile);
-        rename($versionFile, $versionFileBak);
-
-        try {
-            $client = $this->getMockClient();
-            $version = $client->getVersion();
-        } catch (\Exception $e) {
-            $this->assertEquals('Exception', get_class($e));
-            $this->assertEquals('No VERSION file', $e->getMessage());
-        }
-        rename($versionFileBak, $versionFile);
+        $this->assertEquals($methodVersion, $reflectionVersion);
     }
 }


### PR DESCRIPTION
… and seems more fragile for child libraries.