### PR TITLE
Add handling for SSH Key objects

### DIFF
--- a/src/Endpoints/SshKeys.php
+++ b/src/Endpoints/SshKeys.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace AcquiaCloudApi\Endpoints;
+
+use AcquiaCloudApi\Response\SshKeysResponse;
+use AcquiaCloudApi\Response\SshKeyResponse;
+use AcquiaCloudApi\Response\OperationResponse;
+
+/**
+ * Class SshKeys
+ *
+ * @package AcquiaCloudApi\CloudApi
+ */
+class SshKeys extends CloudApiBase implements CloudApiInterface
+{
+
+    /**
+     * Returns a list of SSL keys.
+     *
+     * @return SshKeysResponse<SshKeyResponse>
+     */
+    public function getAll(): SshKeysResponse
+    {
+        return new SshKeysResponse(
+            $this->client->request(
+                'get',
+                "/account/ssh-keys"
+            )
+        );
+    }
+
+    /**
+     * Returns a specific key by key ID.
+     *
+     * @param  string $keyId
+     * @return SshKeyResponse
+     */
+    public function get($keyId): SshKeyResponse
+    {
+        return new SshKeyResponse(
+            $this->client->request(
+                'get',
+                "/account/ssh-keys/${keyId}"
+            )
+        );
+    }
+
+    /**
+     * Create an SSH key.
+     *
+     * @param  string $label
+     * @param  string $public_key
+     * @return OperationResponse
+     */
+    public function create($label, $public_key): OperationResponse
+    {
+
+        $options = [
+            'json' => [
+                'label' => $label,
+                'public_key' => $public_key
+            ],
+        ];
+
+        return new OperationResponse(
+            $this->client->request('post', "/account/ssh-keys", $options)
+        );
+    }
+
+    /**
+     * Delete a specific key by ID.
+     *
+     * @param  string  $keyId
+     * @return OperationResponse
+     */
+    public function delete($keyId): OperationResponse
+    {
+        return new OperationResponse(
+            $this->client->request('delete', "/account/ssh-keys/${keyId}")
+        );
+    }
+}

--- a/src/Response/SshKeyResponse.php
+++ b/src/Response/SshKeyResponse.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace AcquiaCloudApi\Response;
+
+/**
+ * Class SshKeyResponse
+ *
+ * @package AcquiaCloudApi\Response
+ */
+class SshKeyResponse
+{
+    /**
+     * @var string $uuid
+     */
+    public $uuid;
+
+    /**
+     * @var string $label
+     */
+    public $label;
+
+    /**
+     * @var string $public_key
+     */
+    public $public_key;
+
+    /**
+     * @var string $fingerprint
+     */
+    public $fingerprint;
+
+    /**
+     * @var string $created_at
+     */
+    public $created_at;
+
+    /**
+     * @var object $links
+     */
+    public $links;
+
+    /**
+     * SshKeyResponse constructor.
+     *
+     * @param object $sshkey
+     */
+
+    public function __construct($sshkey)
+    {
+        $this->uuid = $sshkey->uuid;
+        $this->label = $sshkey->label;
+        $this->public_key = $sshkey->public_key;
+        $this->fingerprint = $sshkey->fingerprint;
+        $this->created_at = $sshkey->created_at;
+        $this->links = $sshkey->_links;
+    }
+}

--- a/src/Response/SshKeysResponse.php
+++ b/src/Response/SshKeysResponse.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace AcquiaCloudApi\Response;
+
+/**
+ * @template TValue
+ * @template-extends \ArrayObject<int,TValue>
+ */
+class SshKeysResponse extends \ArrayObject
+{
+
+    /**
+     * @param array<object> $sshkeys
+     */
+    public function __construct($sshkeys)
+    {
+        parent::__construct(
+            array_map(
+                function ($sshkey) {
+                    return new SshKeyResponse($sshkey);
+                },
+                $sshkeys
+            ),
+            self::ARRAY_AS_PROPS
+        );
+    }
+}

--- a/tests/Endpoints/SshKeysTest.php
+++ b/tests/Endpoints/SshKeysTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+use AcquiaCloudApi\Endpoints\SshKeys;
+
+class SshKeysTest extends CloudApiTestCase
+{
+    /**
+     * @var mixed[] $properties
+     */
+    public $properties = [
+        'uuid',
+        'label',
+        'public_key'
+    ];
+
+    public function testGetKeys(): void
+    {
+
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/SshKeys/getAllSshKeys.json');
+        $client = $this->getMockClient($response);
+
+        /** @var \AcquiaCloudApi\Connector\ClientInterface $client */
+        $key = new SshKeys($client);
+        $result = $key->getAll();
+
+        $this->assertInstanceOf('\ArrayObject', $result);
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\SshKeysResponse', $result);
+        $this->assertNotEmpty($result);
+
+        foreach ($result as $record) {
+            $this->assertInstanceOf('\AcquiaCloudApi\Response\SshKeyResponse', $record);
+
+            foreach ($this->properties as $property) {
+                $this->assertObjectHasAttribute($property, $record);
+            }
+        }
+    }
+
+    public function testGetKey(): void
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/SshKeys/getSshKey.json');
+        $client = $this->getMockClient($response);
+
+        /** @var \AcquiaCloudApi\Connector\ClientInterface $client */
+        $key = new SshKeys($client);
+        $result = $key->get('1bc40e0d-da9f-4915-a264-624a03edcbd8');
+
+        $this->assertNotInstanceOf('\AcquiaCloudApi\Response\SshKeysResponse', $result);
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\SshKeyResponse', $result);
+
+        foreach ($this->properties as $property) {
+              $this->assertObjectHasAttribute($property, $result);
+        }
+    }
+
+    public function testCreateSshKey(): void
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/SshKeys/createSshKey.json');
+        $client = $this->getMockClient($response);
+
+        /** @var \AcquiaCloudApi\Connector\ClientInterface $client */
+        $key = new SshKeys($client);
+        $result = $key->create(
+            'Test SSH Key 3',
+            'sha-rsa...= Test Key 3'
+        );
+
+        $requestOptions = [
+            'json' => [
+                'label' => 'Test SSH Key 3',
+                'public_key' => 'sha-rsa...= Test Key 3'
+            ],
+        ];
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $this->assertEquals('Adding SSH key.', $result->message);
+    }
+
+    public function testDeleteSshKey(): void
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/SshKeys/deleteSshKey.json');
+        $client = $this->getMockClient($response);
+
+        /** @var \AcquiaCloudApi\Connector\ClientInterface $client */
+        $key = new SshKeys($client);
+        $result = $key->delete('1bc40e0d-da9f-4915-a264-624a03edcbd8');
+
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $this->assertEquals('Removed SSH key.', $result->message);
+    }
+}

--- a/tests/Fixtures/Endpoints/SshKeys/createSshKey.json
+++ b/tests/Fixtures/Endpoints/SshKeys/createSshKey.json
@@ -1,0 +1,3 @@
+{
+    "message": "Adding SSH key."
+}

--- a/tests/Fixtures/Endpoints/SshKeys/deleteSshKey.json
+++ b/tests/Fixtures/Endpoints/SshKeys/deleteSshKey.json
@@ -1,0 +1,3 @@
+{
+    "message": "Removed SSH key."
+}

--- a/tests/Fixtures/Endpoints/SshKeys/getAllSshKeys.json
+++ b/tests/Fixtures/Endpoints/SshKeys/getAllSshKeys.json
@@ -1,0 +1,66 @@
+{
+  "total": 2,
+  "pagination": {
+    "total": 2,
+    "limit": 2,
+    "offset": 0
+  },
+  "_links": {
+    "self": {
+      "href": "https://cloud.acquia.com/api/account/ssh-keys"
+    },
+    "parent": {
+      "href": "https://cloud.acquia.com/api/account"
+    },
+    "limit": {
+      "href": "https://cloud.acquia.com/api/account/ssh-keys{?limit}",
+      "templated": true
+    },
+    "offset": {
+      "href": "https://cloud.acquia.com/api/account/ssh-keys{?offset}",
+      "templated": true
+    },
+    "sort": {
+      "href": "https://cloud.acquia.com/api/account/ssh-keys{?sort}",
+      "templated": true
+    },
+    "filter": {
+      "href": "https://cloud.acquia.com/api/account/ssh-keys{?filter}",
+      "templated": true
+    }
+  },
+  "_embedded": {
+    "items": [
+      {
+        "uuid": "1bc40e0d-da9f-4915-a264-624a03edcbd8",
+        "created_at": "2019-08-09T20:17:52+00:00",
+        "label": "Test SSH key 1",
+        "public_key": "sha-rsa...= Test Key 1",
+        "fingerprint": "7d:4e:ac:69:df:f3:f6:65:a0:cb:cd:63:ac:bf:f9:de",
+        "_links": {
+          "self": {
+            "href": "https://cloud.acquia.com/api/account/ssh-keys/1bc40e0d-da9f-4915-a264-624a03edcbd8"
+          },
+          "parent": {
+            "href": "https://cloud.acquia.com/api/account/ssh-keys"
+          }
+        }
+      },
+      {
+        "uuid": "5d9a096f-e52c-c4bc-9a40-021ffdafbd8b",
+        "created_at": "2021-02-18T18:08:49+00:00",
+        "label": "Test SSH key 2",
+        "public_key": "ssh-rsa...== Test Key 2",
+        "fingerprint": "7a:ce:4c:69:dc:a3:a6:66:a0:cb:de:63:ac:cf:f9:de",
+        "_links": {
+          "self": {
+            "href": "https://cloud.acquia.com/api/account/ssh-keys/5d9a096f-e52c-c4bc-9a40-021ffdafbd8b"
+          },
+          "parent": {
+            "href": "https://cloud.acquia.com/api/account/ssh-keys"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/Fixtures/Endpoints/SshKeys/getSshKey.json
+++ b/tests/Fixtures/Endpoints/SshKeys/getSshKey.json
@@ -1,0 +1,15 @@
+{
+  "uuid": "1bc40e0d-da9f-4915-a264-624a03edcbd8",
+  "created_at": "2019-08-09T20:17:52+00:00",
+  "label": "Test SSH key 1",
+  "public_key": "sha-rsa...= Test Key 1",
+  "fingerprint": "7d:4e:ac:69:df:f3:f6:65:a0:cb:cd:63:ac:bf:f9:de",
+  "_links": {
+    "self": {
+      "href": "https://cloud.acquia.com/api/account/ssh-keys/1bc40e0d-da9f-4915-a264-624a03edcbd8"
+    },
+    "parent": {
+      "href": "https://cloud.acquia.com/api/account/ssh-keys"
+    }
+  }
+}


### PR DESCRIPTION
Adds Endpoint and Response classes for SshKeys based on `account/ssh-keys` and the respective tests as well.