### PR TITLE
Add subscription models

### DIFF
--- a/src/Endpoints/Subscriptions.php
+++ b/src/Endpoints/Subscriptions.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace AcquiaCloudApi\Endpoints;
+
+use AcquiaCloudApi\Response\OperationResponse;
+use AcquiaCloudApi\Response\SubscriptionResponse;
+use AcquiaCloudApi\Response\SubscriptionsResponse;
+
+class Subscriptions extends CloudApiBase implements CloudApiInterface
+{
+    /**
+     * Shows all Subscriptions.
+     *
+     * @return SubscriptionsResponse<SubscriptionResponse>
+     */
+    public function getAll(): SubscriptionsResponse
+    {
+        return new SubscriptionsResponse($this->client->request('get', '/subscriptions'));
+    }
+
+    /**
+     * Shows information about an subscription.
+     *
+     * @param  string $subscriptionUuid
+     * @return SubscriptionResponse
+     */
+    public function get($subscriptionUuid): SubscriptionResponse
+    {
+        return new SubscriptionResponse(
+            $this->client->request(
+                'get',
+                "/subscriptions/${subscriptionUuid}"
+            )
+        );
+    }
+
+    /**
+     * Renames an subscription.
+     *
+     * @param  string $subscriptionUuid
+     * @param  string $name
+     * @return OperationResponse
+     */
+    public function rename($subscriptionUuid, $name): OperationResponse
+    {
+
+        $options = [
+            'json' => [
+                'name' => $name,
+            ],
+        ];
+
+        return new OperationResponse(
+            $this->client->request(
+                'put',
+                "/subscriptions/${subscriptionUuid}",
+                $options
+            )
+        );
+    }
+}

--- a/src/Response/SubscriptionResponse.php
+++ b/src/Response/SubscriptionResponse.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace AcquiaCloudApi\Response;
+
+class SubscriptionResponse
+{
+    /**
+     * @var int $id
+     */
+    public $id;
+
+    /**
+     * @var string $uuid
+     */
+    public $uuid;
+
+    /**
+     * @var string $name
+     */
+    public $name;
+
+    /**
+     * @var string $start_at
+     */
+    public $start_at;
+
+    /**
+     * @var string $expire_at
+     */
+    public $expire_at;
+
+    /**
+     * @var object $product
+     */
+    public $product;
+
+    /**
+     * @var int $applications_total
+     */
+    public $applications_total;
+
+    /**
+     * @var int $applications_used
+     */
+    public $applications_used;
+
+    /**
+     * @var int $advisory_hours_total
+     */
+    public $advisory_hours_total;
+
+    /**
+     * @var int $advisory_hours_used
+     */
+    public $advisory_hours_used;
+
+    /**
+     * @var object $organization
+     */
+    public $organization;
+
+    /**
+     * @var object $flags
+     */
+    public $flags;
+
+    /**
+     * @var object $links
+     */
+    public $links;
+
+    /**
+     * @param object $subscription
+     */
+    public function __construct($subscription)
+    {
+        $this->id = $subscription->id;
+        $this->uuid = $subscription->uuid;
+        $this->name = $subscription->name;
+        $this->start_at = $subscription->start_at;
+        $this->expire_at = $subscription->expire_at;
+        $this->product = $subscription->product;
+        $this->applications_total = $subscription->applications_total;
+        $this->applications_used = $subscription->applications_used;
+        $this->advisory_hours_total = $subscription->advisory_hours_total;
+        $this->advisory_hours_used = $subscription->advisory_hours_used;
+        $this->organization = $subscription->organization;
+        $this->flags = $subscription->flags;
+        $this->links = $subscription->_links;
+    }
+}

--- a/src/Response/SubscriptionsResponse.php
+++ b/src/Response/SubscriptionsResponse.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace AcquiaCloudApi\Response;
+
+/**
+ * @template TValue
+ * @template-extends \ArrayObject<int,TValue>
+ */
+class SubscriptionsResponse extends \ArrayObject
+{
+
+    /**
+     * @param array<object> $subscriptions
+     */
+    public function __construct($subscriptions)
+    {
+        parent::__construct(
+            array_map(
+                function ($subscription) {
+                    return new SubscriptionResponse($subscription);
+                },
+                $subscriptions
+            ),
+            self::ARRAY_AS_PROPS
+        );
+    }
+}

--- a/tests/Endpoints/SubscriptionsTest.php
+++ b/tests/Endpoints/SubscriptionsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace AcquiaCloudApi\Tests\Endpoints;
+
+use AcquiaCloudApi\Tests\CloudApiTestCase;
+use AcquiaCloudApi\Endpoints\Subscriptions;
+
+class SubscriptionsTest extends CloudApiTestCase
+{
+    /**
+     * @var mixed[] $properties
+     */
+    protected $properties = [
+        'uuid',
+        'name',
+        'start_at',
+        'expire_at',
+        'product',
+        'applications_total',
+        'applications_used',
+        'advisory_hours_total',
+        'advisory_hours_used',
+        'organization',
+        'flags',
+        'links'
+    ];
+
+    public function testGetSubscriptions(): void
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/Subscriptions/getAllSubscriptions.json');
+        $client = $this->getMockClient($response);
+
+        /** @var \AcquiaCloudApi\Connector\ClientInterface $client */
+        $subscription = new Subscriptions($client);
+        $result = $subscription->getAll();
+
+        $this->assertInstanceOf('\ArrayObject', $result);
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\SubscriptionsResponse', $result);
+        $this->assertNotEmpty($result);
+
+        foreach ($result as $record) {
+            $this->assertInstanceOf('\AcquiaCloudApi\Response\SubscriptionResponse', $record);
+
+            foreach ($this->properties as $property) {
+                $this->assertObjectHasAttribute($property, $record);
+            }
+        }
+    }
+
+    public function testGetSubscription(): void
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/Subscriptions/getSubscription.json');
+        $client = $this->getMockClient($response);
+
+        /** @var \AcquiaCloudApi\Connector\ClientInterface $client */
+        $subscription = new Subscriptions($client);
+        $result = $subscription->get('8533debb-ae4e-427b-aa34-731719b4201a');
+
+        $this->assertNotInstanceOf('\AcquiaCloudApi\Response\SubscriptionsResponse', $result);
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\SubscriptionResponse', $result);
+
+        foreach ($this->properties as $property) {
+            $this->assertObjectHasAttribute($property, $result);
+        }
+    }
+
+    public function testRenameSubscription(): void
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/Subscriptions/renameSubscription.json');
+        $client = $this->getMockClient($response);
+
+        /** @var \AcquiaCloudApi\Connector\ClientInterface $client */
+        $subscription = new Subscriptions($client);
+        $result = $subscription->rename('8533debb-ae4e-427b-aa34-731719b4201a', "My subscription's new name");
+
+        $requestOptions = [
+            'json' => [
+                'name' => "My subscription's new name",
+            ],
+        ];
+
+        $this->assertEquals($requestOptions, $this->getRequestOptions($client));
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $this->assertEquals('Subscription updated.', $result->message);
+    }
+}

--- a/tests/Fixtures/Endpoints/Subscriptions/getAllSubscriptions.json
+++ b/tests/Fixtures/Endpoints/Subscriptions/getAllSubscriptions.json
@@ -1,0 +1,159 @@
+{
+    "total": 3,
+    "_links": {
+        "self": {
+            "href": "{baseUri}/subscriptions"
+        },
+        "sort": {
+            "href": "{baseUri}/subscriptions{?sort}",
+            "templated": true
+        },
+        "filter": {
+            "href": "{baseUri}/subscriptions{?filter}",
+            "templated": true
+        },
+        "limit": {
+            "href": "{baseUri}/subscriptions{?limit}",
+            "templated": true
+        },
+        "parent": {
+            "href": "{baseUri}/"
+        }
+    },
+    "_embedded": {
+        "items": [
+            {
+                "id": 123,
+                "uuid": "faa297f3-f59a-4abc-8d71-904f51bcb1c5",
+                "name": "Acquia Cloud Free Subscription",
+                "start_at": "2011-03-28T00:00:00",
+                "expire_at": "2015-11-11T00:00:00",
+                "product": {
+                    "id": 1890149,
+                    "name": "Acquia Cloud Free",
+                    "type": "free"
+                },
+                "applications_total": 3,
+                "applications_used": 1,
+                "advisory_hours_total": 1.23,
+                "advisory_hours_used": 4.56,
+                "organization": {
+                    "uuid": "39f38840-c494-4622-80a5-fc40269cb42d",
+                    "name": "Acquia Inc."
+                },
+                "flags": {
+                    "active": true,
+                    "expired": true,
+                    "zuora": false
+                },
+                "_links": {
+                    "self": {
+                        "href": "{baseUri}/subscriptions/faa297f3-f59a-4abc-8d71-904f51bcb1c5"
+                    }
+                },
+                "_embedded": {
+                    "organization": {
+                        "uuid": "39f38840-c494-4622-80a5-fc40269cb42d",
+                        "name": "Acquia Inc.",
+                        "_links": {
+                            "self": {
+                                "href": "{baseUri}/organizations/39f38840-c494-4622-80a5-fc40269cb42d"
+                            },
+                            "parent": {
+                                "href": "{baseUri}/organizations"
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "id": 222,
+                "uuid": "36496037-6eb5-482d-8549-e45e1718f2b7",
+                "name": "My Acquia Subscription",
+                "start_at": "2012-05-15T12:00:00Z",
+                "expire_at": "2015-05-15T12:00:00Z",
+                "product": {
+                    "id": 8999,
+                    "name": "Enterprise",
+                    "type": "enterprise"
+                },
+                "applications_total": 5,
+                "applications_used": 2,
+                "advisory_hours_total": 2.34,
+                "advisory_hours_used": 5.67,
+                "organization": {
+                    "uuid": "93c97126-2870-47f0-9ffd-9a92033c443e",
+                    "name": "My Organization"
+                },
+                "flags": {
+                    "active": true,
+                    "expired": true,
+                    "zuora": false
+                },
+                "_links": {
+                    "self": {
+                        "href": "{baseUri}/subscriptions/36496037-6eb5-482d-8549-e45e1718f2b7"
+                    }
+                },
+                "_embedded": {
+                    "organization": {
+                        "uuid": "93c97126-2870-47f0-9ffd-9a92033c443e",
+                        "name": "My Organization",
+                        "_links": {
+                            "self": {
+                                "href": "{baseUri}/organizations/93c97126-2870-47f0-9ffd-9a92033c443e"
+                            },
+                            "parent": {
+                                "href": "{baseUri}/organizations"
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "id": 333,
+                "uuid": "2d92f652-882c-458a-8183-4d9cef7c2fde",
+                "name": "My Acquia Subscription 2",
+                "start_at": "2012-05-15T12:00:00Z",
+                "expire_at": "2015-05-15T12:00:00Z",
+                "product": {
+                    "id": 8999,
+                    "name": "Enterprise",
+                    "type": "enterprise"
+                },
+                "applications_total": 5,
+                "applications_used": 2,
+                "advisory_hours_total": 3.45,
+                "advisory_hours_used": 6.78,
+                "organization": {
+                    "uuid": "93c97126-2870-47f0-9ffd-9a92033c443e",
+                    "name": "My Organization"
+                },
+                "flags": {
+                    "active": true,
+                    "expired": true,
+                    "zuora": false
+                },
+                "_links": {
+                    "self": {
+                        "href": "{baseUri}/subscriptions/2d92f652-882c-458a-8183-4d9cef7c2fde"
+                    }
+                },
+                "_embedded": {
+                    "organization": {
+                        "uuid": "93c97126-2870-47f0-9ffd-9a92033c443e",
+                        "name": "My Organization",
+                        "_links": {
+                            "self": {
+                                "href": "{baseUri}/organizations/93c97126-2870-47f0-9ffd-9a92033c443e"
+                            },
+                            "parent": {
+                                "href": "{baseUri}/organizations"
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/tests/Fixtures/Endpoints/Subscriptions/getSubscription.json
+++ b/tests/Fixtures/Endpoints/Subscriptions/getSubscription.json
@@ -1,0 +1,59 @@
+{
+    "id": 329876,
+    "uuid": "8533debb-ae4e-427b-aa34-731719b4201a",
+    "name": "My Subscription",
+    "start_at": "2015-05-13T00:00:00",
+    "expire_at": "2018-05-12T00:00:00",
+    "product": {
+        "id": 8999,
+        "name": "Enterprise",
+        "type": "enterprise"
+    },
+    "applications_total": 10,
+    "applications_used": 0,
+    "advisory_hours_total": 0,
+    "advisory_hours_used": 0,
+    "organization": {
+        "uuid": "93c97126-2870-47f0-9ffd-9a92033c443e",
+        "name": "My Organization"
+    },
+    "flags": {
+        "active": true,
+        "expired": true,
+        "zuora": false
+    },
+    "_links": {
+        "self": {
+            "href": "{baseUri}/subscriptions/8533debb-ae4e-427b-aa34-731719b4201a"
+        },
+        "applications": {
+            "href": "{baseUri}/subscriptions/8533debb-ae4e-427b-aa34-731719b4201a/applications"
+        },
+        "entitlements": {
+            "href": "{baseUri}/subscriptions/8533debb-ae4e-427b-aa34-731719b4201a/entitlements"
+        },
+        "ides": {
+            "href": "{baseUri}/subscriptions/8533debb-ae4e-427b-aa34-731719b4201a/ides"
+        },
+        "shield-acl": {
+            "href": "{baseUri}/subscriptions/8533debb-ae4e-427b-aa34-731719b4201a/shield-acl"
+        },
+        "parent": {
+            "href": "{baseUri}/subscriptions"
+        }
+    },
+    "_embedded": {
+        "organization": {
+            "uuid": "93c97126-2870-47f0-9ffd-9a92033c443e",
+            "name": "My Organization",
+            "_links": {
+                "self": {
+                    "href": "{baseUri}/organizations/93c97126-2870-47f0-9ffd-9a92033c443e"
+                },
+                "parent": {
+                    "href": "{baseUri}/organizations"
+                }
+            }
+        }
+    }
+}

--- a/tests/Fixtures/Endpoints/Subscriptions/renameSubscription.json
+++ b/tests/Fixtures/Endpoints/Subscriptions/renameSubscription.json
@@ -1,0 +1,3 @@
+{
+    "message": "Subscription updated."
+}


### PR DESCRIPTION
In looking briefly at #192 I realize that we didn't have a basic model for [Subscriptions](http://cloudapi-docs.acquia.com/#/Subscriptions) which need a number of items and endpoints embellished, but this at least gets the basic object in place.