### PR TITLE
[tests] install from dist to speed up tests

### DIFF
--- a/.github/workflows/mt.yml
+++ b/.github/workflows/mt.yml
@@ -27,17 +27,6 @@ jobs:
           extensions: pcov
           coverage: pcov
 
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php-versions }}-
-
       - name: Install dependencies
         run: |
           composer install --no-progress --no-suggest --no-interaction

--- a/.github/workflows/mt.yml
+++ b/.github/workflows/mt.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer install --prefer-source --no-progress --no-suggest --no-interaction
+          composer install --no-progress --no-suggest --no-interaction
 
       - name: Download Infection
         run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -36,19 +36,7 @@ jobs:
     - name: Validate composer.json and composer.lock
       run: composer validate
 
-    - name: Get Composer Cache Directory
-      id: composer-cache
-      run: |
-        echo "::set-output name=dir::$(composer config cache-files-dir)"
-    - uses: actions/cache@v2
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-php-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-${{ matrix.php-versions }}-
-
     - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
       run: composer install --no-progress --no-suggest --no-interaction
 
     - name: Run test suite

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --prefer-source --no-progress --no-suggest --no-interaction
+      run: composer install --no-progress --no-suggest --no-interaction
 
     - name: Run test suite
       run: composer run-script test

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,11 @@
             "League\\OAuth2\\Client\\Test\\": "vendor/league/oauth2-client/test/src/"
         }
     },
+    "config": {
+        "preferred-install": {
+            "league/oauth2-client": "source"
+        }
+    },
     "scripts": {
         "lint": [
             "find src -name '*.php' -print0 | xargs -0 -n1 php -l",

--- a/composer.lock
+++ b/composer.lock
@@ -4467,5 +4467,5 @@
         "php": ">=7.3"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Tests currently take 10 minutes to run, half of which is just installing Composer dependencies, I think because of the giant source repos being cloned.

Installation from source was added in the following commit, but I'm not sure why, presumably to accommodate the League OAuth client (which excludes tests): https://github.com/typhonius/acquia-php-sdk-v2/commit/6cf85f55bd75c10603bce66c48f131d458836149

I don't see why we'd need to install from source, and dist should be an order of magnitude faster.

Edit: indeed, down from 10 minutes to 45 seconds!