### PR TITLE
[tests] no-suggest is deprecated

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,7 +37,7 @@ jobs:
       run: composer validate
 
     - name: Install dependencies
-      run: composer install --no-progress --no-suggest --no-interaction
+      run: composer install --no-progress --no-interaction
 
     - name: Run test suite
       run: composer run-script test


### PR DESCRIPTION
Warning in tests:
>  You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.