### PR TITLE
Auto-merge dependency updates

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,28 @@
+name: Merge dependency updates
+on:
+  workflow_run:
+    types:
+      - "completed"
+    workflows:
+      - "Acquia PHP SDK v2 build and test"
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
+    steps:
+    - name: "Get PR information"
+      uses: potiuk/get-workflow-origin@v1_3
+      id: source-run-info
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        sourceRunId: ${{ github.event.workflow_run.id }}
+    - run: 'gh pr merge --squash https://github.com/${{ env.GITHUB_REPOSITORY }}/pull/${{ env.GITHUB_PR }}'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_PR: ${{ steps.source-run-info.outputs.pullRequestNumber }}


### PR DESCRIPTION
There's not much value in manual review of dependency updates, and no point in me being a click-monkey. If tests pass, they should just be merged automatically.

This can't really be tested until it's merged. But you can see essentially the same script in action in our other repos, i.e. https://github.com/acquia/drupal-recommended-project/blob/master/.github/workflows/automerge.yml