### PR TITLE
Remove advisory_hours_used and advisory_hours_total.

### DIFF
--- a/src/Response/SubscriptionResponse.php
+++ b/src/Response/SubscriptionResponse.php
@@ -45,16 +45,6 @@ class SubscriptionResponse
     public $applications_used;
 
     /**
-     * @var int $advisory_hours_total
-     */
-    public $advisory_hours_total;
-
-    /**
-     * @var int $advisory_hours_used
-     */
-    public $advisory_hours_used;
-
-    /**
      * @var object $organization
      */
     public $organization;
@@ -82,8 +72,6 @@ class SubscriptionResponse
         $this->product = $subscription->product;
         $this->applications_total = $subscription->applications_total;
         $this->applications_used = $subscription->applications_used;
-        $this->advisory_hours_total = $subscription->advisory_hours_total;
-        $this->advisory_hours_used = $subscription->advisory_hours_used;
         $this->organization = $subscription->organization;
         $this->flags = $subscription->flags;
         $this->links = $subscription->_links;

--- a/tests/Endpoints/SubscriptionsTest.php
+++ b/tests/Endpoints/SubscriptionsTest.php
@@ -18,8 +18,6 @@ class SubscriptionsTest extends CloudApiTestCase
         'product',
         'applications_total',
         'applications_used',
-        'advisory_hours_total',
-        'advisory_hours_used',
         'organization',
         'flags',
         'links'

--- a/tests/Fixtures/Endpoints/Subscriptions/getAllSubscriptions.json
+++ b/tests/Fixtures/Endpoints/Subscriptions/getAllSubscriptions.json
@@ -35,8 +35,6 @@
                 },
                 "applications_total": 3,
                 "applications_used": 1,
-                "advisory_hours_total": 1.23,
-                "advisory_hours_used": 4.56,
                 "organization": {
                     "uuid": "39f38840-c494-4622-80a5-fc40269cb42d",
                     "name": "Acquia Inc."
@@ -79,8 +77,6 @@
                 },
                 "applications_total": 5,
                 "applications_used": 2,
-                "advisory_hours_total": 2.34,
-                "advisory_hours_used": 5.67,
                 "organization": {
                     "uuid": "93c97126-2870-47f0-9ffd-9a92033c443e",
                     "name": "My Organization"
@@ -123,8 +119,6 @@
                 },
                 "applications_total": 5,
                 "applications_used": 2,
-                "advisory_hours_total": 3.45,
-                "advisory_hours_used": 6.78,
                 "organization": {
                     "uuid": "93c97126-2870-47f0-9ffd-9a92033c443e",
                     "name": "My Organization"

--- a/tests/Fixtures/Endpoints/Subscriptions/getSubscription.json
+++ b/tests/Fixtures/Endpoints/Subscriptions/getSubscription.json
@@ -11,8 +11,6 @@
     },
     "applications_total": 10,
     "applications_used": 0,
-    "advisory_hours_total": 0,
-    "advisory_hours_used": 0,
     "organization": {
         "uuid": "93c97126-2870-47f0-9ffd-9a92033c443e",
         "name": "My Organization"


### PR DESCRIPTION
These properties have been removed from the API.