### PR TITLE
Type all endpoints, code cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 vendor
 tests/logs
 .idea
-.phpunit.result.cache
+build

--- a/.phplint.yml
+++ b/.phplint.yml
@@ -1,0 +1,8 @@
+path: ./
+jobs: 10
+cache: build/phplint.cache
+extensions:
+  - php
+exclude:
+  - vendor
+warning: false

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,12 @@
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.0.0",
         "phpunit/phpunit": "^9",
-        "phpstan/phpstan": "^0.12",
-        "phpstan/phpstan-phpunit": "^0.12",
+        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan-phpunit": "^1.0",
         "squizlabs/php_codesniffer": "3.*",
         "eloquent/phony-phpunit": "^7",
-        "ext-json": "*"
+        "ext-json": "*",
+        "overtrue/phplint": "^3.2"
     },
     "autoload": {
         "psr-4": {
@@ -47,10 +48,7 @@
         }
     },
     "scripts": {
-        "lint": [
-            "find src -name '*.php' -print0 | xargs -0 -n1 php -l",
-            "find tests -name '*.php' -print0 | xargs -0 -n1 php -l"
-        ],
+        "lint": "phplint",
         "cs": "phpcs --standard=PSR12 -n src tests --ignore=./tests/logs/*",
         "cbf": "phpcbf --standard=PSR12 -n src tests --ignore=./tests/logs/*",
         "unit": "php -dpcov.enabled=1 -dpcov.directory=. -dpcov.exclude='~vendor~' ./vendor/bin/phpunit --configuration=phpunit.xml --testdox",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "809f038a847c45c6c207335f3f1f1f63",
+    "content-hash": "1b3abc0314f8dda2b09e42c32791fdd4",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1869,6 +1869,46 @@
             "time": "2022-03-03T13:19:32+00:00"
         },
         {
+            "name": "n98/junit-xml",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cmuench/junit-xml.git",
+                "reference": "0017dd92ac8cb619f02e32f4cffd768cfe327c73"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cmuench/junit-xml/zipball/0017dd92ac8cb619f02e32f4cffd768cfe327c73",
+                "reference": "0017dd92ac8cb619f02e32f4cffd768cfe327c73",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "N98\\JUnitXml\\": "src/N98/JUnitXml"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Münch",
+                    "email": "c.muench@netz98.de"
+                }
+            ],
+            "description": "JUnit XML Document generation library",
+            "support": {
+                "issues": "https://github.com/cmuench/junit-xml/issues",
+                "source": "https://github.com/cmuench/junit-xml/tree/1.1.0"
+            },
+            "time": "2020-12-25T09:08:58+00:00"
+        },
+        {
             "name": "nikic/php-parser",
             "version": "v4.14.0",
             "source": {
@@ -1923,6 +1963,82 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
             },
             "time": "2022-05-31T20:59:12+00:00"
+        },
+        {
+            "name": "overtrue/phplint",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/overtrue/phplint.git",
+                "reference": "c3021ad8cebd802ad3f4924c45f508803e0b80e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/overtrue/phplint/zipball/c3021ad8cebd802ad3f4924c45f508803e0b80e5",
+                "reference": "c3021ad8cebd802ad3f4924c45f508803e0b80e5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "n98/junit-xml": "1.1.0",
+                "php": "^5.5.9 || ^7.0",
+                "symfony/console": "^3.2 || ^4.0 || ^5.0",
+                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
+                "symfony/process": "^3.3 || ^4.0 || ^5.0",
+                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "brainmaestro/composer-git-hooks": "^2.7",
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "jakub-onderka/php-console-highlighter": "^0.3.2 || ^0.4"
+            },
+            "bin": [
+                "bin/phplint"
+            ],
+            "type": "library",
+            "extra": {
+                "hooks": {
+                    "pre-commit": [
+                        "composer fix-style"
+                    ],
+                    "pre-push": [
+                        "composer check-style"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Overtrue\\PHPLint\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "overtrue",
+                    "email": "anzhengchao@gmail.com"
+                }
+            ],
+            "description": "`phplint` is a tool that can speed up linting of php files by running several lint processes at once.",
+            "keywords": [
+                "check",
+                "lint",
+                "phplint",
+                "syntax"
+            ],
+            "support": {
+                "issues": "https://github.com/overtrue/phplint/issues",
+                "source": "https://github.com/overtrue/phplint/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/overtrue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-07-12T07:37:04+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2347,20 +2463,20 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.99",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7"
+                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b4d40f1d759942f523be267a1bab6884f46ca3f7",
-                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c53312ecc575caf07b0e90dee43883fdf90ca67c",
+                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0"
+                "php": "^7.2|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -2370,11 +2486,6 @@
                 "phpstan.phar"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.12-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "bootstrap.php"
@@ -2387,7 +2498,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.99"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.2"
             },
             "funding": [
                 {
@@ -2407,39 +2518,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-12T20:09:55+00:00"
+            "time": "2022-07-20T09:57:31+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "0.12.22",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "7c01ef93bf128b4ac8bdad38c54b2a4fd6b0b3cc"
+                "reference": "4a3c437c09075736285d1cabb5c75bf27ed0bc84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/7c01ef93bf128b4ac8bdad38c54b2a4fd6b0b3cc",
-                "reference": "7c01ef93bf128b4ac8bdad38c54b2a4fd6b0b3cc",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/4a3c437c09075736285d1cabb5c75bf27ed0bc84",
+                "reference": "4a3c437c09075736285d1cabb5c75bf27ed0bc84",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0",
-                "phpstan/phpstan": "^0.12.92"
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.5.0"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
             },
             "require-dev": {
+                "nikic/php-parser": "^4.13.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-strict-rules": "^0.12.6",
+                "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5"
             },
             "type": "phpstan-extension",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "0.12-dev"
-                },
                 "phpstan": {
                     "includes": [
                         "extension.neon",
@@ -2459,9 +2568,9 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/0.12.22"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.1.1"
             },
-            "time": "2021-08-12T10:53:43+00:00"
+            "time": "2022-04-20T15:24:25+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3905,16 +4014,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.4.8",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "9f8964f56f7234f8ace16f66cb3fbae950c04e68"
+                "reference": "ec79e03125c1d2477e43dde8528535d90cc78379"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/9f8964f56f7234f8ace16f66cb3fbae950c04e68",
-                "reference": "9f8964f56f7234f8ace16f66cb3fbae950c04e68",
+                "url": "https://api.github.com/repos/symfony/config/zipball/ec79e03125c1d2477e43dde8528535d90cc78379",
+                "reference": "ec79e03125c1d2477e43dde8528535d90cc78379",
                 "shasum": ""
             },
             "require": {
@@ -3964,7 +4073,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.4.8"
+                "source": "https://github.com/symfony/config/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -3980,20 +4089,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-12T16:02:29+00:00"
+            "time": "2022-07-20T13:00:38+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.8",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "ffe3aed36c4d60da2cf1b0a1cee6b8f2e5fa881b"
+                "reference": "535846c7ee6bc4dd027ca0d93220601456734b10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/ffe3aed36c4d60da2cf1b0a1cee6b8f2e5fa881b",
-                "reference": "ffe3aed36c4d60da2cf1b0a1cee6b8f2e5fa881b",
+                "url": "https://api.github.com/repos/symfony/console/zipball/535846c7ee6bc4dd027ca0d93220601456734b10",
+                "reference": "535846c7ee6bc4dd027ca0d93220601456734b10",
                 "shasum": ""
             },
             "require": {
@@ -4063,7 +4172,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.8"
+                "source": "https://github.com/symfony/console/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -4079,20 +4188,83 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-12T16:02:29+00:00"
+            "time": "2022-07-22T10:42:43+00:00"
         },
         {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.25.0",
+            "name": "symfony/finder",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783"
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "7872a66f57caffa2916a584db1aa7f12adc76f8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/81b86b50cf841a64252b439e738e97f4a34e2783",
-                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/7872a66f57caffa2916a584db1aa7f12adc76f8c",
+                "reference": "7872a66f57caffa2916a584db1aa7f12adc76f8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v5.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-07-29T07:37:50+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.26.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "433d05519ce6990bf3530fba6957499d327395c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/433d05519ce6990bf3530fba6957499d327395c2",
+                "reference": "433d05519ce6990bf3530fba6957499d327395c2",
                 "shasum": ""
             },
             "require": {
@@ -4104,7 +4276,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4144,7 +4316,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -4160,20 +4332,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-23T21:10:46+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+                "reference": "219aa369ceff116e673852dce47c3a41794c14bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/219aa369ceff116e673852dce47c3a41794c14bd",
+                "reference": "219aa369ceff116e673852dce47c3a41794c14bd",
                 "shasum": ""
             },
             "require": {
@@ -4185,7 +4357,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4228,7 +4400,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -4244,20 +4416,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "5de4ba2d41b15f9bd0e19b2ab9674135813ec98f"
+                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/5de4ba2d41b15f9bd0e19b2ab9674135813ec98f",
-                "reference": "5de4ba2d41b15f9bd0e19b2ab9674135813ec98f",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/13f6d1271c663dc5ae9fb843a8f16521db7687a1",
+                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1",
                 "shasum": ""
             },
             "require": {
@@ -4266,7 +4438,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4307,7 +4479,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -4323,7 +4495,69 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-13T13:58:11+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "6e75fe6874cbc7e4773d049616ab450eff537bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/6e75fe6874cbc7e4773d049616ab450eff537bf1",
+                "reference": "6e75fe6874cbc7e4773d049616ab450eff537bf1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-06-27T16:58:25+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -4389,16 +4623,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.8",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "3c061a76bff6d6ea427d85e12ad1bb8ed8cd43e8"
+                "reference": "5eb661e49ad389e4ae2b6e4df8d783a8a6548322"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/3c061a76bff6d6ea427d85e12ad1bb8ed8cd43e8",
-                "reference": "3c061a76bff6d6ea427d85e12ad1bb8ed8cd43e8",
+                "url": "https://api.github.com/repos/symfony/string/zipball/5eb661e49ad389e4ae2b6e4df8d783a8a6548322",
+                "reference": "5eb661e49ad389e4ae2b6e4df8d783a8a6548322",
                 "shasum": ""
             },
             "require": {
@@ -4455,7 +4689,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.8"
+                "source": "https://github.com/symfony/string/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -4471,20 +4705,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-19T10:40:37+00:00"
+            "time": "2022-07-24T16:15:25+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.3",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e80f87d2c9495966768310fc531b487ce64237a2"
+                "reference": "05d4ea560f3402c6c116afd99fdc66e60eda227e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e80f87d2c9495966768310fc531b487ce64237a2",
-                "reference": "e80f87d2c9495966768310fc531b487ce64237a2",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/05d4ea560f3402c6c116afd99fdc66e60eda227e",
+                "reference": "05d4ea560f3402c6c116afd99fdc66e60eda227e",
                 "shasum": ""
             },
             "require": {
@@ -4530,7 +4764,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.3"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -4546,7 +4780,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-26T16:32:32+00:00"
+            "time": "2022-06-27T16:58:25+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,7 @@
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
     verbose="true"
+    cacheResultFile="build/.phpunit.result.cache"
     >
     <testsuites>
         <testsuite name="Acquia Cloud PHP SDK Binding">

--- a/src/Connector/Connector.php
+++ b/src/Connector/Connector.php
@@ -5,6 +5,8 @@ namespace AcquiaCloudApi\Connector;
 use League\OAuth2\Client\Provider\GenericProvider;
 use League\OAuth2\Client\Token\AccessTokenInterface;
 use GuzzleHttp\Client as GuzzleClient;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Filesystem\Path;
 
@@ -18,7 +20,7 @@ class Connector implements ConnectorInterface
     /**
      * @var string The base URI for Acquia Cloud API.
      */
-    protected $baseUri;
+    protected string $baseUri;
 
     /**
      * @var GenericProvider The OAuth 2.0 provider to use in communication.
@@ -28,12 +30,12 @@ class Connector implements ConnectorInterface
     /**
      * @var GuzzleClient The client used to make HTTP requests to the API.
      */
-    protected $client;
+    protected GuzzleClient $client;
 
     /**
-     * @var AccessTokenInterface The generated OAuth 2.0 access token.
+     * @var AccessTokenInterface|null The generated OAuth 2.0 access token.
      */
-    protected $accessToken;
+    protected ?AccessTokenInterface $accessToken;
 
     /**
      * @inheritdoc
@@ -69,7 +71,7 @@ class Connector implements ConnectorInterface
     /**
      * @inheritdoc
      */
-    public function createRequest($verb, $path)
+    public function createRequest(string $verb, string $path): RequestInterface
     {
         if (!isset($this->accessToken) || $this->accessToken->hasExpired()) {
             $directory = sprintf('%s%s%s', Path::getHomeDirectory(), \DIRECTORY_SEPARATOR, '.acquia-php-sdk-v2');
@@ -91,8 +93,9 @@ class Connector implements ConnectorInterface
 
     /**
      * @inheritdoc
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function sendRequest($verb, $path, $options)
+    public function sendRequest(string $verb, string $path, array $options): ResponseInterface
     {
         $request = $this->createRequest($verb, $path);
         return $this->client->send($request, $options);

--- a/src/Connector/ConnectorInterface.php
+++ b/src/Connector/ConnectorInterface.php
@@ -40,18 +40,18 @@ interface ConnectorInterface
      *
      * @return RequestInterface
      */
-    public function createRequest($verb, $path);
+    public function createRequest(string $verb, string $path): RequestInterface;
 
     /**
      * Sends the request to the API using Guzzle.
      *
      * @param string $verb
      * @param string $path
-     * @param array<string, array>  $options
+     * @param array<string, array<mixed>>  $options
      *
      * @return ResponseInterface
      */
-    public function sendRequest($verb, $path, $options);
+    public function sendRequest(string $verb, string $path, array $options): ResponseInterface;
 
     /**
      * @return string

--- a/src/Endpoints/Account.php
+++ b/src/Endpoints/Account.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\StreamInterface;
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Account extends CloudApiBase implements CloudApiInterface
+class Account extends CloudApiBase
 {
     /**
      * Returns details about your account.
@@ -27,7 +27,7 @@ class Account extends CloudApiBase implements CloudApiInterface
      *
      * @return StreamInterface
      */
-    public function getDrushAliases()
+    public function getDrushAliases(): StreamInterface
     {
         return $this->client->stream('get', '/account/drush-aliases/download');
     }

--- a/src/Endpoints/Applications.php
+++ b/src/Endpoints/Applications.php
@@ -4,16 +4,16 @@ namespace AcquiaCloudApi\Endpoints;
 
 use AcquiaCloudApi\Response\ApplicationResponse;
 use AcquiaCloudApi\Response\ApplicationsResponse;
+use AcquiaCloudApi\Response\OperationResponse;
 use AcquiaCloudApi\Response\TagResponse;
 use AcquiaCloudApi\Response\TagsResponse;
-use AcquiaCloudApi\Response\OperationResponse;
 
 /**
  * Class Applications
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Applications extends CloudApiBase implements CloudApiInterface
+class Applications extends CloudApiBase
 {
     /**
      * Shows all applications.
@@ -28,15 +28,16 @@ class Applications extends CloudApiBase implements CloudApiInterface
     /**
      * Shows information about an application.
      *
-     * @param  string $applicationUuid
+     * @param string $applicationUuid
+     *
      * @return ApplicationResponse
      */
-    public function get($applicationUuid): ApplicationResponse
+    public function get(string $applicationUuid): ApplicationResponse
     {
         return new ApplicationResponse(
             $this->client->request(
                 'get',
-                "/applications/${applicationUuid}"
+                "/applications/$applicationUuid"
             )
         );
     }
@@ -44,11 +45,12 @@ class Applications extends CloudApiBase implements CloudApiInterface
     /**
      * Renames an application.
      *
-     * @param  string $applicationUuid
-     * @param  string $name
+     * @param string $applicationUuid
+     * @param string $name
+     *
      * @return OperationResponse
      */
-    public function rename($applicationUuid, $name): OperationResponse
+    public function rename(string $applicationUuid, string $name): OperationResponse
     {
 
         $options = [
@@ -60,7 +62,7 @@ class Applications extends CloudApiBase implements CloudApiInterface
         return new OperationResponse(
             $this->client->request(
                 'put',
-                "/applications/${applicationUuid}",
+                "/applications/$applicationUuid",
                 $options
             )
         );
@@ -69,16 +71,17 @@ class Applications extends CloudApiBase implements CloudApiInterface
     /**
      * Returns a list of application tags associated with this application.
      *
-     * @param  string $applicationUuid
+     * @param string $applicationUuid
+     *
      * @return TagsResponse<TagResponse>
      */
-    public function getAllTags($applicationUuid): TagsResponse
+    public function getAllTags(string $applicationUuid): TagsResponse
     {
 
         return new TagsResponse(
             $this->client->request(
                 'get',
-                "/applications/${applicationUuid}/tags"
+                "/applications/$applicationUuid/tags"
             )
         );
     }
@@ -86,12 +89,13 @@ class Applications extends CloudApiBase implements CloudApiInterface
     /**
      * Creates a new application tag.
      *
-     * @param  string $applicationUuid
-     * @param  string $name
-     * @param  string $color
+     * @param string $applicationUuid
+     * @param string $name
+     * @param string $color
+     *
      * @return OperationResponse
      */
-    public function createTag($applicationUuid, $name, $color): OperationResponse
+    public function createTag(string $applicationUuid, string $name, string $color): OperationResponse
     {
 
         $options = [
@@ -104,7 +108,7 @@ class Applications extends CloudApiBase implements CloudApiInterface
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/applications/${applicationUuid}/tags",
+                "/applications/$applicationUuid/tags",
                 $options
             )
         );
@@ -113,17 +117,18 @@ class Applications extends CloudApiBase implements CloudApiInterface
     /**
      * Deletes an application tag.
      *
-     * @param  string $applicationUuid
-     * @param  string $tagName
+     * @param string $applicationUuid
+     * @param string $tagName
+     *
      * @return OperationResponse
      */
-    public function deleteTag($applicationUuid, $tagName): OperationResponse
+    public function deleteTag(string $applicationUuid, string $tagName): OperationResponse
     {
 
         return new OperationResponse(
             $this->client->request(
                 'delete',
-                "/applications/${applicationUuid}/tags/${tagName}"
+                "/applications/$applicationUuid/tags/$tagName"
             )
         );
     }

--- a/src/Endpoints/CloudApiBase.php
+++ b/src/Endpoints/CloudApiBase.php
@@ -14,7 +14,7 @@ abstract class CloudApiBase implements CloudApiInterface
     /**
      * @var ClientInterface The API client.
      */
-    protected $client;
+    protected ClientInterface $client;
 
     /**
      * Client constructor.

--- a/src/Endpoints/Code.php
+++ b/src/Endpoints/Code.php
@@ -11,20 +11,21 @@ use AcquiaCloudApi\Response\OperationResponse;
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Code extends CloudApiBase implements CloudApiInterface
+class Code extends CloudApiBase
 {
     /**
      * Shows all code branches and tags in an application.
      *
-     * @param  string $applicationUuid
+     * @param string $applicationUuid
+     *
      * @return BranchesResponse<BranchResponse>
      */
-    public function getAll($applicationUuid): BranchesResponse
+    public function getAll(string $applicationUuid): BranchesResponse
     {
         return new BranchesResponse(
             $this->client->request(
                 'get',
-                "/applications/${applicationUuid}/code"
+                "/applications/$applicationUuid/code"
             )
         );
     }
@@ -32,11 +33,12 @@ class Code extends CloudApiBase implements CloudApiInterface
     /**
      * Deploys a code branch/tag to an environment.
      *
-     * @param  string $environmentUuid
-     * @param  string $branch
+     * @param string $environmentUuid
+     * @param string $branch
+     *
      * @return OperationResponse
      */
-    public function switch($environmentUuid, $branch): OperationResponse
+    public function switch(string $environmentUuid, string $branch): OperationResponse
     {
 
         $options = [
@@ -48,7 +50,7 @@ class Code extends CloudApiBase implements CloudApiInterface
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/code/actions/switch",
+                "/environments/$environmentUuid/code/actions/switch",
                 $options
             )
         );
@@ -59,10 +61,11 @@ class Code extends CloudApiBase implements CloudApiInterface
      *
      * @param string $environmentFromUuid
      * @param string $environmentToUuid
-     * @param string $commitMessage
+     * @param string|null $commitMessage
+     *
      * @return OperationResponse
      */
-    public function deploy($environmentFromUuid, $environmentToUuid, $commitMessage = null): OperationResponse
+    public function deploy(string $environmentFromUuid, string $environmentToUuid, string $commitMessage = null): OperationResponse
     {
 
         $options = [
@@ -75,7 +78,7 @@ class Code extends CloudApiBase implements CloudApiInterface
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentToUuid}/code",
+                "/environments/$environmentToUuid/code",
                 $options
             )
         );

--- a/src/Endpoints/Crons.php
+++ b/src/Endpoints/Crons.php
@@ -2,8 +2,8 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\CronsResponse;
 use AcquiaCloudApi\Response\CronResponse;
+use AcquiaCloudApi\Response\CronsResponse;
 use AcquiaCloudApi\Response\OperationResponse;
 
 /**
@@ -11,20 +11,21 @@ use AcquiaCloudApi\Response\OperationResponse;
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Crons extends CloudApiBase implements CloudApiInterface
+class Crons extends CloudApiBase
 {
     /**
      * Show all cron tasks for an environment.
      *
-     * @param  string $environmentUuid The environment ID
+     * @param string $environmentUuid The environment ID
+     *
      * @return CronsResponse<CronResponse>
      */
-    public function getAll($environmentUuid): CronsResponse
+    public function getAll(string $environmentUuid): CronsResponse
     {
         return new CronsResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/crons"
+                "/environments/$environmentUuid/crons"
             )
         );
     }
@@ -32,16 +33,17 @@ class Crons extends CloudApiBase implements CloudApiInterface
     /**
      * Get information about a cron task.
      *
-     * @param  string $environmentUuid The environment ID
-     * @param  int    $cronId
+     * @param string $environmentUuid The environment ID
+     * @param int $cronId
+     *
      * @return CronResponse
      */
-    public function get($environmentUuid, $cronId): CronResponse
+    public function get(string $environmentUuid, int $cronId): CronResponse
     {
         return new CronResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/crons/${cronId}"
+                "/environments/$environmentUuid/crons/$cronId"
             )
         );
     }
@@ -49,14 +51,15 @@ class Crons extends CloudApiBase implements CloudApiInterface
     /**
      * Add a cron task.
      *
-     * @param  string $environmentUuid
-     * @param  string $command
-     * @param  string $frequency
-     * @param  string $label
-     * @param  string $serverId
+     * @param string $environmentUuid
+     * @param string $command
+     * @param string $frequency
+     * @param string $label
+     * @param string|null $serverId
+     *
      * @return OperationResponse
      */
-    public function create($environmentUuid, $command, $frequency, $label, $serverId = null): OperationResponse
+    public function create(string $environmentUuid, string $command, string $frequency, string $label, string $serverId = null): OperationResponse
     {
 
         $options = [
@@ -64,27 +67,28 @@ class Crons extends CloudApiBase implements CloudApiInterface
                 'command' => $command,
                 'frequency' => $frequency,
                 'label' => $label,
-                'server_id' => $serverId
+                'server_id' => $serverId,
             ],
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/environments/${environmentUuid}/crons", $options)
+            $this->client->request('post', "/environments/$environmentUuid/crons", $options)
         );
     }
 
     /**
      * Update a cron task.
      *
-     * @param  string $environmentUuid
-     * @param  string $cronId
-     * @param  string $command
-     * @param  string $frequency
-     * @param  string $label
-     * @param  string $serverId
+     * @param string $environmentUuid
+     * @param string $cronId
+     * @param string $command
+     * @param string $frequency
+     * @param string $label
+     * @param string|null $serverId
+     *
      * @return OperationResponse
      */
-    public function update($environmentUuid, $cronId, $command, $frequency, $label, $serverId = null): OperationResponse
+    public function update(string $environmentUuid, string $cronId, string $command, string $frequency, string $label, string $serverId = null): OperationResponse
     {
 
         $options = [
@@ -92,42 +96,44 @@ class Crons extends CloudApiBase implements CloudApiInterface
                 'command' => $command,
                 'frequency' => $frequency,
                 'label' => $label,
-                'server_id' => $serverId
+                'server_id' => $serverId,
             ],
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/environments/${environmentUuid}/crons/${cronId}", $options)
+            $this->client->request('post', "/environments/$environmentUuid/crons/$cronId", $options)
         );
     }
 
     /**
      * Delete a cron task.
      *
-     * @param  string $environmentUuid
-     * @param  int    $cronId
+     * @param string $environmentUuid
+     * @param int $cronId
+     *
      * @return OperationResponse
      */
-    public function delete($environmentUuid, $cronId): OperationResponse
+    public function delete(string $environmentUuid, int $cronId): OperationResponse
     {
         return new OperationResponse(
-            $this->client->request('delete', "/environments/${environmentUuid}/crons/${cronId}")
+            $this->client->request('delete', "/environments/$environmentUuid/crons/$cronId")
         );
     }
 
     /**
      * Disable a cron task.
      *
-     * @param  string $environmentUuid
-     * @param  int    $cronId
+     * @param string $environmentUuid
+     * @param int $cronId
+     *
      * @return OperationResponse
      */
-    public function disable($environmentUuid, $cronId): OperationResponse
+    public function disable(string $environmentUuid, int $cronId): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/crons/${cronId}/actions/disable"
+                "/environments/$environmentUuid/crons/$cronId/actions/disable"
             )
         );
     }
@@ -135,16 +141,17 @@ class Crons extends CloudApiBase implements CloudApiInterface
     /**
      * Enable a cron task.
      *
-     * @param  string $environmentUuid
-     * @param  int    $cronId
+     * @param string $environmentUuid
+     * @param int $cronId
+     *
      * @return OperationResponse
      */
-    public function enable($environmentUuid, $cronId): OperationResponse
+    public function enable(string $environmentUuid, int $cronId): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/crons/${cronId}/actions/enable"
+                "/environments/$environmentUuid/crons/$cronId/actions/enable"
             )
         );
     }

--- a/src/Endpoints/DatabaseBackups.php
+++ b/src/Endpoints/DatabaseBackups.php
@@ -2,8 +2,8 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\BackupsResponse;
 use AcquiaCloudApi\Response\BackupResponse;
+use AcquiaCloudApi\Response\BackupsResponse;
 use AcquiaCloudApi\Response\OperationResponse;
 use Psr\Http\Message\StreamInterface;
 
@@ -12,21 +12,22 @@ use Psr\Http\Message\StreamInterface;
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class DatabaseBackups extends CloudApiBase implements CloudApiInterface
+class DatabaseBackups extends CloudApiBase
 {
     /**
      * Backup a database.
      *
-     * @param  string $environmentUuid
-     * @param  string $dbName
+     * @param string $environmentUuid
+     * @param string $dbName
+     *
      * @return OperationResponse
      */
-    public function create($environmentUuid, $dbName): OperationResponse
+    public function create(string $environmentUuid, string $dbName): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/databases/${dbName}/backups"
+                "/environments/$environmentUuid/databases/$dbName/backups"
             )
         );
     }
@@ -34,16 +35,17 @@ class DatabaseBackups extends CloudApiBase implements CloudApiInterface
     /**
      * Shows all database backups in an environment.
      *
-     * @param  string $environmentUuid
-     * @param  string $dbName
+     * @param string $environmentUuid
+     * @param string $dbName
+     *
      * @return BackupsResponse<BackupResponse>
      */
-    public function getAll($environmentUuid, $dbName): BackupsResponse
+    public function getAll(string $environmentUuid, string $dbName): BackupsResponse
     {
         return new BackupsResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/databases/${dbName}/backups"
+                "/environments/$environmentUuid/databases/$dbName/backups"
             )
         );
     }
@@ -51,17 +53,18 @@ class DatabaseBackups extends CloudApiBase implements CloudApiInterface
     /**
      * Gets information about a database backup.
      *
-     * @param  string $environmentUuid
-     * @param  string $dbName
-     * @param  int    $backupId
+     * @param string $environmentUuid
+     * @param string $dbName
+     * @param int $backupId
+     *
      * @return BackupResponse
      */
-    public function get($environmentUuid, $dbName, $backupId): BackupResponse
+    public function get(string $environmentUuid, string $dbName, int $backupId): BackupResponse
     {
         return new BackupResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/databases/${dbName}/backups/${backupId}"
+                "/environments/$environmentUuid/databases/$dbName/backups/$backupId"
             )
         );
     }
@@ -69,17 +72,18 @@ class DatabaseBackups extends CloudApiBase implements CloudApiInterface
     /**
      * Restores a database backup to a database in an environment.
      *
-     * @param  string $environmentUuid
-     * @param  string $dbName
-     * @param  int    $backupId
+     * @param string $environmentUuid
+     * @param string $dbName
+     * @param int $backupId
+     *
      * @return OperationResponse
      */
-    public function restore($environmentUuid, $dbName, $backupId): OperationResponse
+    public function restore(string $environmentUuid, string $dbName, int $backupId): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/databases/${dbName}/backups/${backupId}/actions/restore"
+                "/environments/$environmentUuid/databases/$dbName/backups/$backupId/actions/restore"
             )
         );
     }
@@ -87,33 +91,35 @@ class DatabaseBackups extends CloudApiBase implements CloudApiInterface
     /**
      * Downloads a database backup.
      *
-     * @param  string $environmentUuid
-     * @param  string $dbName
-     * @param  int    $backupId
+     * @param string $environmentUuid
+     * @param string $dbName
+     * @param int $backupId
+     *
      * @return StreamInterface
      */
-    public function download($environmentUuid, $dbName, $backupId): StreamInterface
+    public function download(string $environmentUuid, string $dbName, int $backupId): StreamInterface
     {
         return $this->client->stream(
             'get',
-            "/environments/${environmentUuid}/databases/${dbName}/backups/${backupId}/actions/download"
+            "/environments/$environmentUuid/databases/$dbName/backups/$backupId/actions/download"
         );
     }
 
     /**
      * Deletes a database backup.
      *
-     * @param  string $environmentUuid
-     * @param  string $dbName
-     * @param  int    $backupId
+     * @param string $environmentUuid
+     * @param string $dbName
+     * @param int $backupId
+     *
      * @return OperationResponse
      */
-    public function delete($environmentUuid, $dbName, $backupId): OperationResponse
+    public function delete(string $environmentUuid, string $dbName, int $backupId): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'delete',
-                "/environments/${environmentUuid}/databases/${dbName}/backups/${backupId}"
+                "/environments/$environmentUuid/databases/$dbName/backups/$backupId"
             )
         );
     }

--- a/src/Endpoints/Databases.php
+++ b/src/Endpoints/Databases.php
@@ -2,8 +2,8 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\DatabasesResponse;
 use AcquiaCloudApi\Response\DatabaseResponse;
+use AcquiaCloudApi\Response\DatabasesResponse;
 use AcquiaCloudApi\Response\OperationResponse;
 
 /**
@@ -11,20 +11,21 @@ use AcquiaCloudApi\Response\OperationResponse;
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Databases extends CloudApiBase implements CloudApiInterface
+class Databases extends CloudApiBase
 {
     /**
      * Shows all databases in an application.
      *
-     * @param  string $applicationUuid
+     * @param string $applicationUuid
+     *
      * @return DatabasesResponse<DatabaseResponse>
      */
-    public function getAll($applicationUuid): DatabasesResponse
+    public function getAll(string $applicationUuid): DatabasesResponse
     {
         return new DatabasesResponse(
             $this->client->request(
                 'get',
-                "/applications/${applicationUuid}/databases"
+                "/applications/$applicationUuid/databases"
             )
         );
     }
@@ -32,11 +33,12 @@ class Databases extends CloudApiBase implements CloudApiInterface
     /**
      * Create a new database.
      *
-     * @param  string $applicationUuid
-     * @param  string $name
+     * @param string $applicationUuid
+     * @param string $name
+     *
      * @return OperationResponse
      */
-    public function create($applicationUuid, $name): OperationResponse
+    public function create(string $applicationUuid, string $name): OperationResponse
     {
         $options = [
             'json' => [
@@ -45,21 +47,22 @@ class Databases extends CloudApiBase implements CloudApiInterface
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/applications/${applicationUuid}/databases", $options)
+            $this->client->request('post', "/applications/$applicationUuid/databases", $options)
         );
     }
 
     /**
      * Delete a database.
      *
-     * @param  string $applicationUuid
-     * @param  string $name
+     * @param string $applicationUuid
+     * @param string $name
+     *
      * @return OperationResponse
      */
-    public function delete($applicationUuid, $name): OperationResponse
+    public function delete(string $applicationUuid, string $name): OperationResponse
     {
         return new OperationResponse(
-            $this->client->request('delete', "/applications/${applicationUuid}/databases/${name}")
+            $this->client->request('delete', "/applications/$applicationUuid/databases/$name")
         );
     }
 
@@ -69,16 +72,17 @@ class Databases extends CloudApiBase implements CloudApiInterface
      * This action will delete all tables of the database in ALL environments
      * within this application.
      *
-     * @param  string $applicationUuid
-     * @param  string $name
+     * @param string $applicationUuid
+     * @param string $name
+     *
      * @return OperationResponse
      */
-    public function truncate($applicationUuid, $name): OperationResponse
+    public function truncate(string $applicationUuid, string $name): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/applications/${applicationUuid}/databases/${name}/actions/erase"
+                "/applications/$applicationUuid/databases/$name/actions/erase"
             )
         );
     }
@@ -86,12 +90,13 @@ class Databases extends CloudApiBase implements CloudApiInterface
     /**
      * Copies a database from an environment to an environment.
      *
-     * @param  string $environmentFromUuid
-     * @param  string $dbName
-     * @param  string $environmentToUuid
+     * @param string $environmentFromUuid
+     * @param string $dbName
+     * @param string $environmentToUuid
+     *
      * @return OperationResponse
      */
-    public function copy($environmentFromUuid, $dbName, $environmentToUuid): OperationResponse
+    public function copy(string $environmentFromUuid, string $dbName, string $environmentToUuid): OperationResponse
     {
         $options = [
             'json' => [
@@ -101,7 +106,7 @@ class Databases extends CloudApiBase implements CloudApiInterface
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/environments/${environmentToUuid}/databases", $options)
+            $this->client->request('post', "/environments/$environmentToUuid/databases", $options)
         );
     }
 }

--- a/src/Endpoints/Domains.php
+++ b/src/Endpoints/Domains.php
@@ -2,31 +2,32 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\DomainsResponse;
 use AcquiaCloudApi\Response\DomainResponse;
-use AcquiaCloudApi\Response\OperationResponse;
-use AcquiaCloudApi\Response\MetricsResponse;
+use AcquiaCloudApi\Response\DomainsResponse;
 use AcquiaCloudApi\Response\MetricResponse;
+use AcquiaCloudApi\Response\MetricsResponse;
+use AcquiaCloudApi\Response\OperationResponse;
 
 /**
  * Class Domains
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Domains extends CloudApiBase implements CloudApiInterface
+class Domains extends CloudApiBase
 {
     /**
      * Shows all domains on an environment.
      *
-     * @param  string $environmentUuid
+     * @param string $environmentUuid
+     *
      * @return DomainsResponse<DomainResponse>
      */
-    public function getAll($environmentUuid): DomainsResponse
+    public function getAll(string $environmentUuid): DomainsResponse
     {
         return new DomainsResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/domains"
+                "/environments/$environmentUuid/domains"
             )
         );
     }
@@ -34,16 +35,17 @@ class Domains extends CloudApiBase implements CloudApiInterface
     /**
      * Return details about a domain.
      *
-     * @param  string $environmentUuid
-     * @param  string $domain
+     * @param string $environmentUuid
+     * @param string $domain
+     *
      * @return DomainResponse
      */
-    public function get($environmentUuid, $domain): DomainResponse
+    public function get(string $environmentUuid, string $domain): DomainResponse
     {
         return new DomainResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/domains/${domain}"
+                "/environments/$environmentUuid/domains/$domain"
             )
         );
     }
@@ -51,11 +53,12 @@ class Domains extends CloudApiBase implements CloudApiInterface
     /**
      * Adds a domain to an environment.
      *
-     * @param  string $environmentUuid
-     * @param  string $hostname
+     * @param string $environmentUuid
+     * @param string $hostname
+     *
      * @return OperationResponse
      */
-    public function create($environmentUuid, $hostname): OperationResponse
+    public function create(string $environmentUuid, string $hostname): OperationResponse
     {
 
         $options = [
@@ -65,32 +68,34 @@ class Domains extends CloudApiBase implements CloudApiInterface
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/environments/${environmentUuid}/domains", $options)
+            $this->client->request('post', "/environments/$environmentUuid/domains", $options)
         );
     }
 
     /**
      * Deletes a domain from an environment.
      *
-     * @param  string $environmentUuid
-     * @param  string $domain
+     * @param string $environmentUuid
+     * @param string $domain
+     *
      * @return OperationResponse
      */
-    public function delete($environmentUuid, $domain): OperationResponse
+    public function delete(string $environmentUuid, string $domain): OperationResponse
     {
         return new OperationResponse(
-            $this->client->request('delete', "/environments/${environmentUuid}/domains/${domain}")
+            $this->client->request('delete', "/environments/$environmentUuid/domains/$domain")
         );
     }
 
     /**
      * Purges cache for selected domains in an environment.
      *
-     * @param  string        $environmentUuid
-     * @param  array<string> $domains
+     * @param string $environmentUuid
+     * @param array<string> $domains
+     *
      * @return OperationResponse
      */
-    public function purge($environmentUuid, array $domains): OperationResponse
+    public function purge(string $environmentUuid, array $domains): OperationResponse
     {
         $options = [
             'json' => [
@@ -101,7 +106,7 @@ class Domains extends CloudApiBase implements CloudApiInterface
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/actions/clear-caches",
+                "/environments/$environmentUuid/actions/clear-caches",
                 $options
             )
         );
@@ -110,33 +115,36 @@ class Domains extends CloudApiBase implements CloudApiInterface
     /**
      * Purges cache for a single domain in an environment.
      *
-     * @param  string        $environmentUuid
-     * @param  string        $domain
+     * @param string $environmentUuid
+     * @param string $domain
+     *
      * @return OperationResponse
      */
-    public function clearDomainCache($environmentUuid, $domain): OperationResponse
+    public function clearDomainCache(string $environmentUuid, string $domain): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/domains/${domain}/actions/clear-caches"
+                "/environments/$environmentUuid/domains/$domain/actions/clear-caches"
             )
         );
     }
 
     /**
-     * Retrieves the scan data for a domain name that is part of this environment.
+     * Retrieves the scan data for a domain name that is part of this
+     * environment.
      *
-     * @param  string $environmentUuid
-     * @param  string $domain
+     * @param string $environmentUuid
+     * @param string $domain
+     *
      * @return MetricsResponse<MetricResponse>
      */
-    public function metrics($environmentUuid, $domain): MetricsResponse
+    public function metrics(string $environmentUuid, string $domain): MetricsResponse
     {
         return new MetricsResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/domains/${domain}/metrics/uptime"
+                "/environments/$environmentUuid/domains/$domain/metrics/uptime"
             )
         );
     }
@@ -144,16 +152,17 @@ class Domains extends CloudApiBase implements CloudApiInterface
     /**
      * Returns details about the domain.
      *
-     * @param  string $environmentUuid
-     * @param  string $domain
+     * @param string $environmentUuid
+     * @param string $domain
+     *
      * @return DomainResponse
      */
-    public function status($environmentUuid, $domain): DomainResponse
+    public function status(string $environmentUuid, string $domain): DomainResponse
     {
         return new DomainResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/domains/${domain}/status"
+                "/environments/$environmentUuid/domains/$domain/status"
             )
         );
     }

--- a/src/Endpoints/Environments.php
+++ b/src/Endpoints/Environments.php
@@ -11,16 +11,17 @@ use AcquiaCloudApi\Response\OperationResponse;
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Environments extends CloudApiBase implements CloudApiInterface
+class Environments extends CloudApiBase
 {
     /**
      * Copies files from an environment to another environment.
      *
-     * @param  string $environmentUuidFrom
-     * @param  string $environmentUuidTo
+     * @param string $environmentUuidFrom
+     * @param string $environmentUuidTo
+     *
      * @return OperationResponse
      */
-    public function copyFiles($environmentUuidFrom, $environmentUuidTo): OperationResponse
+    public function copyFiles(string $environmentUuidFrom, string $environmentUuidTo): OperationResponse
     {
         $options = [
             'json' => [
@@ -29,22 +30,23 @@ class Environments extends CloudApiBase implements CloudApiInterface
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/environments/${environmentUuidTo}/files", $options)
+            $this->client->request('post', "/environments/$environmentUuidTo/files", $options)
         );
     }
 
     /**
      * Gets information about an environment.
      *
-     * @param  string $environmentUuid
+     * @param string $environmentUuid
+     *
      * @return EnvironmentResponse
      */
-    public function get($environmentUuid): EnvironmentResponse
+    public function get(string $environmentUuid): EnvironmentResponse
     {
         return new EnvironmentResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}"
+                "/environments/$environmentUuid"
             )
         );
     }
@@ -52,15 +54,16 @@ class Environments extends CloudApiBase implements CloudApiInterface
     /**
      * Shows all environments in an application.
      *
-     * @param  string $applicationUuid
+     * @param string $applicationUuid
+     *
      * @return EnvironmentsResponse<EnvironmentResponse>
      */
-    public function getAll($applicationUuid): EnvironmentsResponse
+    public function getAll(string $applicationUuid): EnvironmentsResponse
     {
         return new EnvironmentsResponse(
             $this->client->request(
                 'get',
-                "/applications/${applicationUuid}/environments"
+                "/applications/$applicationUuid/environments"
             )
         );
     }
@@ -68,11 +71,12 @@ class Environments extends CloudApiBase implements CloudApiInterface
     /**
      * Modifies configuration settings for an environment.
      *
-     * @param  string  $environmentUuid
-     * @param  mixed[] $config
+     * @param string $environmentUuid
+     * @param mixed[] $config
+     *
      * @return OperationResponse
      */
-    public function update($environmentUuid, array $config): OperationResponse
+    public function update(string $environmentUuid, array $config): OperationResponse
     {
 
         $options = [
@@ -82,7 +86,7 @@ class Environments extends CloudApiBase implements CloudApiInterface
         return new OperationResponse(
             $this->client->request(
                 'put',
-                "/environments/${environmentUuid}",
+                "/environments/$environmentUuid",
                 $options
             )
         );
@@ -91,11 +95,12 @@ class Environments extends CloudApiBase implements CloudApiInterface
     /**
      * Renames an environment.
      *
-     * @param  string $environmentUuid
-     * @param  string $label
+     * @param string $environmentUuid
+     * @param string $label
+     *
      * @return OperationResponse
      */
-    public function rename($environmentUuid, $label): OperationResponse
+    public function rename(string $environmentUuid, string $label): OperationResponse
     {
 
         $options = [
@@ -107,7 +112,7 @@ class Environments extends CloudApiBase implements CloudApiInterface
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/actions/change-label",
+                "/environments/$environmentUuid/actions/change-label",
                 $options
             )
         );
@@ -116,23 +121,25 @@ class Environments extends CloudApiBase implements CloudApiInterface
     /**
      * Enable livedev mode for an environment.
      *
-     * @param  string $environmentUuid
+     * @param string $environmentUuid
+     *
      * @return OperationResponse
      */
-    public function enableLiveDev($environmentUuid): OperationResponse
+    public function enableLiveDev(string $environmentUuid): OperationResponse
     {
         return new OperationResponse(
-            $this->client->request('post', "/environments/${environmentUuid}/livedev/actions/enable")
+            $this->client->request('post', "/environments/$environmentUuid/livedev/actions/enable")
         );
     }
 
     /**
      * Disable livedev mode for an environment.
      *
-     * @param  string $environmentUuid
+     * @param string $environmentUuid
+     *
      * @return OperationResponse
      */
-    public function disableLiveDev($environmentUuid): OperationResponse
+    public function disableLiveDev(string $environmentUuid): OperationResponse
     {
 
         $options = [
@@ -144,7 +151,7 @@ class Environments extends CloudApiBase implements CloudApiInterface
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/livedev/actions/disable",
+                "/environments/$environmentUuid/livedev/actions/disable",
                 $options
             )
         );
@@ -153,15 +160,16 @@ class Environments extends CloudApiBase implements CloudApiInterface
     /**
      * Enable production mode for an environment.
      *
-     * @param  string $environmentUuid
+     * @param string $environmentUuid
+     *
      * @return OperationResponse
      */
-    public function enableProductionMode($environmentUuid): OperationResponse
+    public function enableProductionMode(string $environmentUuid): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/production-mode/actions/enable"
+                "/environments/$environmentUuid/production-mode/actions/enable"
             )
         );
     }
@@ -169,15 +177,16 @@ class Environments extends CloudApiBase implements CloudApiInterface
     /**
      * Disable production mode for an environment.
      *
-     * @param  string $environmentUuid
+     * @param string $environmentUuid
+     *
      * @return OperationResponse
      */
-    public function disableProductionMode($environmentUuid): OperationResponse
+    public function disableProductionMode(string $environmentUuid): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/production-mode/actions/disable"
+                "/environments/$environmentUuid/production-mode/actions/disable"
             )
         );
     }
@@ -185,13 +194,14 @@ class Environments extends CloudApiBase implements CloudApiInterface
     /**
      * Add a new continuous delivery environment to an application.
      *
-     * @param  string        $applicationUuid
-     * @param  string        $label
-     * @param  string        $branch
-     * @param  array<string> $databases
+     * @param string $applicationUuid
+     * @param string $label
+     * @param string $branch
+     * @param array<string> $databases
+     *
      * @return OperationResponse
      */
-    public function create($applicationUuid, $label, $branch, array $databases): OperationResponse
+    public function create(string $applicationUuid, string $label, string $branch, array $databases): OperationResponse
     {
         $options = [
             'json' => [
@@ -204,7 +214,7 @@ class Environments extends CloudApiBase implements CloudApiInterface
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/applications/${applicationUuid}/environments",
+                "/applications/$applicationUuid/environments",
                 $options
             )
         );
@@ -213,15 +223,16 @@ class Environments extends CloudApiBase implements CloudApiInterface
     /**
      * Deletes a CD environment.
      *
-     * @param  string $environmentUuid
+     * @param string $environmentUuid
+     *
      * @return OperationResponse
      */
-    public function delete($environmentUuid): OperationResponse
+    public function delete(string $environmentUuid): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'delete',
-                "/environments/${environmentUuid}"
+                "/environments/$environmentUuid"
             )
         );
     }

--- a/src/Endpoints/IdentityProviders.php
+++ b/src/Endpoints/IdentityProviders.php
@@ -2,16 +2,16 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\OperationResponse;
-use AcquiaCloudApi\Response\IdentityProvidersResponse;
 use AcquiaCloudApi\Response\IdentityProviderResponse;
+use AcquiaCloudApi\Response\IdentityProvidersResponse;
+use AcquiaCloudApi\Response\OperationResponse;
 
 /**
  * Class IdentityProviders
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class IdentityProviders extends CloudApiBase implements CloudApiInterface
+class IdentityProviders extends CloudApiBase
 {
     /**
      * Returns a list of identity providers for the user.
@@ -31,15 +31,16 @@ class IdentityProviders extends CloudApiBase implements CloudApiInterface
     /**
      * Returns a specific identity provider by UUID.
      *
-     * @param  string $idpUuid The identity provider ID
+     * @param string $idpUuid The identity provider ID
+     *
      * @return IdentityProviderResponse
      */
-    public function get($idpUuid): IdentityProviderResponse
+    public function get(string $idpUuid): IdentityProviderResponse
     {
         return new IdentityProviderResponse(
             $this->client->request(
                 'get',
-                "/identity-providers/${idpUuid}"
+                "/identity-providers/$idpUuid"
             )
         );
     }
@@ -47,15 +48,16 @@ class IdentityProviders extends CloudApiBase implements CloudApiInterface
     /**
      * Delete a specific identity provider by UUID.
      *
-     * @param  string $idpUuid
+     * @param string $idpUuid
+     *
      * @return OperationResponse
      */
-    public function delete($idpUuid): OperationResponse
+    public function delete(string $idpUuid): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'delete',
-                "/identity-providers/${idpUuid}"
+                "/identity-providers/$idpUuid"
             )
         );
     }
@@ -63,15 +65,16 @@ class IdentityProviders extends CloudApiBase implements CloudApiInterface
     /**
      * Disables an identity provider by UUID.
      *
-     * @param  string $idpUuid
+     * @param string $idpUuid
+     *
      * @return OperationResponse
      */
-    public function disable($idpUuid): OperationResponse
+    public function disable(string $idpUuid): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/identity-providers/${idpUuid}/actions/disable"
+                "/identity-providers/$idpUuid/actions/disable"
             )
         );
     }
@@ -79,15 +82,16 @@ class IdentityProviders extends CloudApiBase implements CloudApiInterface
     /**
      * Enables an identity provider by UUID.
      *
-     * @param  string $idpUuid
+     * @param string $idpUuid
+     *
      * @return OperationResponse
      */
-    public function enable($idpUuid): OperationResponse
+    public function enable(string $idpUuid): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/identity-providers/${idpUuid}/actions/enable"
+                "/identity-providers/$idpUuid/actions/enable"
             )
         );
     }
@@ -95,14 +99,15 @@ class IdentityProviders extends CloudApiBase implements CloudApiInterface
     /**
      * Updates a identity provider by UUID.
      *
-     * @param  string $idpUuid
-     * @param  string $label
-     * @param  string $entityId
-     * @param  string $ssoUrl
-     * @param  string $certificate
+     * @param string $idpUuid
+     * @param string $label
+     * @param string $entityId
+     * @param string $ssoUrl
+     * @param string $certificate
+     *
      * @return OperationResponse
      */
-    public function update($idpUuid, $label, $entityId, $ssoUrl, $certificate): OperationResponse
+    public function update(string $idpUuid, string $label, string $entityId, string $ssoUrl, string $certificate): OperationResponse
     {
 
         $options = [
@@ -117,7 +122,7 @@ class IdentityProviders extends CloudApiBase implements CloudApiInterface
         return new OperationResponse(
             $this->client->request(
                 'put',
-                "/identity-providers/${idpUuid}",
+                "/identity-providers/$idpUuid",
                 $options
             )
         );

--- a/src/Endpoints/Ides.php
+++ b/src/Endpoints/Ides.php
@@ -2,8 +2,8 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\IdesResponse;
 use AcquiaCloudApi\Response\IdeResponse;
+use AcquiaCloudApi\Response\IdesResponse;
 use AcquiaCloudApi\Response\OperationResponse;
 
 /**
@@ -11,20 +11,21 @@ use AcquiaCloudApi\Response\OperationResponse;
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Ides extends CloudApiBase implements CloudApiInterface
+class Ides extends CloudApiBase
 {
     /**
      * Returns a list of remote IDEs.
      *
-     * @param  string $applicationUuid The application ID
+     * @param string $applicationUuid The application ID
+     *
      * @return IdesResponse<IdeResponse>
      */
-    public function getAll($applicationUuid): IdesResponse
+    public function getAll(string $applicationUuid): IdesResponse
     {
         return new IdesResponse(
             $this->client->request(
                 'get',
-                "/applications/${applicationUuid}/ides"
+                "/applications/$applicationUuid/ides"
             )
         );
     }
@@ -32,15 +33,16 @@ class Ides extends CloudApiBase implements CloudApiInterface
     /**
      * Get remote IDE info.
      *
-     * @param  string $ideUuid The Remote IDE universally unique identifier.
+     * @param string $ideUuid The Remote IDE universally unique identifier.
+     *
      * @return IdeResponse
      */
-    public function get($ideUuid): IdeResponse
+    public function get(string $ideUuid): IdeResponse
     {
         return new IdeResponse(
             $this->client->request(
                 'get',
-                "/ides/${ideUuid}"
+                "/ides/$ideUuid"
             )
         );
     }
@@ -48,11 +50,12 @@ class Ides extends CloudApiBase implements CloudApiInterface
     /**
      * Creates a new remote IDE.
      *
-     * @param  string $applicationUuid
-     * @param  string $label
+     * @param string $applicationUuid
+     * @param string $label
+     *
      * @return OperationResponse
      */
-    public function create($applicationUuid, $label): OperationResponse
+    public function create(string $applicationUuid, string $label): OperationResponse
     {
 
         $options = [
@@ -62,20 +65,21 @@ class Ides extends CloudApiBase implements CloudApiInterface
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/applications/${applicationUuid}/ides", $options)
+            $this->client->request('post', "/applications/$applicationUuid/ides", $options)
         );
     }
 
     /**
      * De-provisions a specific Remote IDE.
      *
-     * @param  string $ideUuid
+     * @param string $ideUuid
+     *
      * @return OperationResponse
      */
-    public function delete($ideUuid): OperationResponse
+    public function delete(string $ideUuid): OperationResponse
     {
         return new OperationResponse(
-            $this->client->request('delete', "/ides/${ideUuid}")
+            $this->client->request('delete', "/ides/$ideUuid")
         );
     }
 }

--- a/src/Endpoints/Insights.php
+++ b/src/Endpoints/Insights.php
@@ -2,12 +2,12 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\InsightsResponse;
-use AcquiaCloudApi\Response\InsightResponse;
-use AcquiaCloudApi\Response\InsightAlertsResponse;
 use AcquiaCloudApi\Response\InsightAlertResponse;
-use AcquiaCloudApi\Response\InsightModulesResponse;
+use AcquiaCloudApi\Response\InsightAlertsResponse;
 use AcquiaCloudApi\Response\InsightModuleResponse;
+use AcquiaCloudApi\Response\InsightModulesResponse;
+use AcquiaCloudApi\Response\InsightResponse;
+use AcquiaCloudApi\Response\InsightsResponse;
 use AcquiaCloudApi\Response\OperationResponse;
 
 /**
@@ -15,36 +15,40 @@ use AcquiaCloudApi\Response\OperationResponse;
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Insights extends CloudApiBase implements CloudApiInterface
+class Insights extends CloudApiBase
 {
     /**
-     * Returns Insight data for all sites associated with the application by its UUID.
+     * Returns Insight data for all sites associated with the application by its
+     * UUID.
      *
-     * @param  string $applicationUuid
+     * @param string $applicationUuid
+     *
      * @return InsightsResponse<InsightResponse>
      */
-    public function getAll($applicationUuid): InsightsResponse
+    public function getAll(string $applicationUuid): InsightsResponse
     {
         return new InsightsResponse(
             $this->client->request(
                 'get',
-                "/applications/${applicationUuid}/insight"
+                "/applications/$applicationUuid/insight"
             )
         );
     }
 
     /**
-     * Returns Insight data for all sites associated with the environment by its UUID.
+     * Returns Insight data for all sites associated with the environment by its
+     * UUID.
      *
-     * @param  string $environmentUuid
+     * @param string $environmentUuid
+     *
      * @return InsightsResponse<InsightResponse>
      */
-    public function getEnvironment($environmentUuid): InsightsResponse
+    public function getEnvironment(string $environmentUuid): InsightsResponse
     {
         return new InsightsResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/insight"
+                "/environments/$environmentUuid/insight"
             )
         );
     }
@@ -52,15 +56,16 @@ class Insights extends CloudApiBase implements CloudApiInterface
     /**
      * Returns insight data for a particular site.
      *
-     * @param  string $siteId
+     * @param string $siteId
+     *
      * @return InsightResponse
      */
-    public function get($siteId): InsightResponse
+    public function get(string $siteId): InsightResponse
     {
         return new InsightResponse(
             $this->client->request(
                 'get',
-                "/insight/${siteId}"
+                "/insight/$siteId"
             )
         );
     }
@@ -68,15 +73,16 @@ class Insights extends CloudApiBase implements CloudApiInterface
     /**
      * Returns a list of Insight alerts for this site.
      *
-     * @param  string $siteId
+     * @param string $siteId
+     *
      * @return InsightAlertsResponse<InsightAlertResponse>
      */
-    public function getAllAlerts($siteId): InsightAlertsResponse
+    public function getAllAlerts(string $siteId): InsightAlertsResponse
     {
         return new InsightAlertsResponse(
             $this->client->request(
                 'get',
-                "/insight/${siteId}/alerts"
+                "/insight/$siteId/alerts"
             )
         );
     }
@@ -84,83 +90,92 @@ class Insights extends CloudApiBase implements CloudApiInterface
     /**
      * Returns a specific Insight alert for this site.
      *
-     * @param  string $siteId
-     * @param  string $alertUuid
+     * @param string $siteId
+     * @param string $alertUuid
+     *
      * @return InsightAlertResponse
      */
-    public function getAlert($siteId, $alertUuid): InsightAlertResponse
+    public function getAlert(string $siteId, string $alertUuid): InsightAlertResponse
     {
         return new InsightAlertResponse(
             $this->client->request(
                 'get',
-                "/insight/${siteId}/alerts/${alertUuid}"
+                "/insight/$siteId/alerts/$alertUuid"
             )
         );
     }
 
     /**
-     * Ignores an alert. An ignored alert will be included will not be counted in the Insight score calculation.
+     * Ignores an alert. An ignored alert will be included will not be counted
+     * in the Insight score calculation.
      *
-     * @param  string $siteId
-     * @param  string $alertUuid
+     * @param string $siteId
+     * @param string $alertUuid
+     *
      * @return OperationResponse
      */
-    public function ignoreAlert($siteId, $alertUuid): OperationResponse
+    public function ignoreAlert(string $siteId, string $alertUuid): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/insight/${siteId}/alerts/${alertUuid}/actions/ignore"
+                "/insight/$siteId/alerts/$alertUuid/actions/ignore"
             )
         );
     }
 
     /**
-     * Restores an alert. A restored alert will be included in the calculation of the Insight score.
+     * Restores an alert. A restored alert will be included in the calculation
+     * of the Insight score.
      *
-     * @param  string $siteId
-     * @param  string $alertUuid
+     * @param string $siteId
+     * @param string $alertUuid
+     *
      * @return OperationResponse
      */
-    public function restoreAlert($siteId, $alertUuid): OperationResponse
+    public function restoreAlert(string $siteId, string $alertUuid): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/insight/${siteId}/alerts/${alertUuid}/actions/restore"
+                "/insight/$siteId/alerts/$alertUuid/actions/restore"
             )
         );
     }
 
     /**
-     * Revokes an Insight install so it can no longer submit data using the Acquia Connector module.
+     * Revokes an Insight install so it can no longer submit data using the
+     * Acquia Connector module.
      *
-     * @param  string $siteId
+     * @param string $siteId
+     *
      * @return OperationResponse
      */
-    public function revoke($siteId): OperationResponse
+    public function revoke(string $siteId): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/insight/${siteId}/actions/revoke"
+                "/insight/$siteId/actions/revoke"
             )
         );
     }
 
     /**
-     * Un-revokes an Insight site so it can once again submit data using the Acquia Connector module.
-     * Note that the site must also be unblocked using the Acquia Connector module.
+     * Un-revokes an Insight site so it can once again submit data using the
+     * Acquia Connector module. Note that the site must also be unblocked using
+     * the Acquia Connector module.
      *
-     * @param  string $siteId
+     * @param string $siteId
+     *
      * @return OperationResponse
      */
-    public function unrevoke($siteId): OperationResponse
+    public function unrevoke(string $siteId): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/insight/${siteId}/actions/unrevoke"
+                "/insight/$siteId/actions/unrevoke"
             )
         );
     }
@@ -168,15 +183,16 @@ class Insights extends CloudApiBase implements CloudApiInterface
     /**
      * Returns a list of Drupal modules for this site.
      *
-     * @param  string $siteId
+     * @param string $siteId
+     *
      * @return InsightModulesResponse<InsightModuleResponse>
      */
-    public function getModules($siteId): InsightModulesResponse
+    public function getModules(string $siteId): InsightModulesResponse
     {
         return new InsightModulesResponse(
             $this->client->request(
                 'get',
-                "/insight/${siteId}/modules"
+                "/insight/$siteId/modules"
             )
         );
     }

--- a/src/Endpoints/LogForwardingDestinations.php
+++ b/src/Endpoints/LogForwardingDestinations.php
@@ -2,29 +2,30 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\OperationResponse;
-use AcquiaCloudApi\Response\LogForwardingDestinationsResponse;
 use AcquiaCloudApi\Response\LogForwardingDestinationResponse;
+use AcquiaCloudApi\Response\LogForwardingDestinationsResponse;
+use AcquiaCloudApi\Response\OperationResponse;
 
 /**
  * Class LogForwardingDestinations
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class LogForwardingDestinations extends CloudApiBase implements CloudApiInterface
+class LogForwardingDestinations extends CloudApiBase
 {
     /**
      * Returns a list of log forwarding destinations.
      *
-     * @param  string $environmentUuid The environment ID
+     * @param string $environmentUuid The environment ID
+     *
      * @return LogForwardingDestinationsResponse<LogForwardingDestinationResponse>
      */
-    public function getAll($environmentUuid): LogForwardingDestinationsResponse
+    public function getAll(string $environmentUuid): LogForwardingDestinationsResponse
     {
         return new LogForwardingDestinationsResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/log-forwarding-destinations"
+                "/environments/$environmentUuid/log-forwarding-destinations"
             )
         );
     }
@@ -32,16 +33,17 @@ class LogForwardingDestinations extends CloudApiBase implements CloudApiInterfac
     /**
      * Returns a specific log forwarding destination.
      *
-     * @param  string $environmentUuid The environment ID
-     * @param  int    $destinationId
+     * @param string $environmentUuid The environment ID
+     * @param int $destinationId
+     *
      * @return LogForwardingDestinationResponse
      */
-    public function get($environmentUuid, $destinationId): LogForwardingDestinationResponse
+    public function get(string $environmentUuid, int $destinationId): LogForwardingDestinationResponse
     {
         return new LogForwardingDestinationResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/log-forwarding-destinations/${destinationId}"
+                "/environments/$environmentUuid/log-forwarding-destinations/$destinationId"
             )
         );
     }
@@ -49,15 +51,16 @@ class LogForwardingDestinations extends CloudApiBase implements CloudApiInterfac
     /**
      * Creates a log forwarding destination.
      *
-     * @param  string  $environmentUuid
-     * @param  string  $label
-     * @param  mixed[] $sources
-     * @param  string  $consumer
-     * @param  mixed[] $credentials
-     * @param  string  $address
+     * @param string $environmentUuid
+     * @param string $label
+     * @param mixed[] $sources
+     * @param string $consumer
+     * @param mixed[] $credentials
+     * @param string $address
+     *
      * @return OperationResponse
      */
-    public function create($environmentUuid, $label, $sources, $consumer, $credentials, $address): OperationResponse
+    public function create(string $environmentUuid, string $label, array $sources, string $consumer, array $credentials, string $address): OperationResponse
     {
 
         $options = [
@@ -66,42 +69,44 @@ class LogForwardingDestinations extends CloudApiBase implements CloudApiInterfac
                 'sources' => $sources,
                 'consumer' => $consumer,
                 'credentials' => $credentials,
-                'address' => $address
+                'address' => $address,
             ],
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/environments/${environmentUuid}/log-forwarding-destinations", $options)
+            $this->client->request('post', "/environments/$environmentUuid/log-forwarding-destinations", $options)
         );
     }
 
     /**
      * Delete a specific log forwarding destination.
      *
-     * @param  string $environmentUuid
-     * @param  int    $destId
+     * @param string $environmentUuid
+     * @param int $destId
+     *
      * @return OperationResponse
      */
-    public function delete($environmentUuid, $destId): OperationResponse
+    public function delete(string $environmentUuid, int $destId): OperationResponse
     {
         return new OperationResponse(
-            $this->client->request('delete', "/environments/${environmentUuid}/log-forwarding-destinations/${destId}")
+            $this->client->request('delete', "/environments/$environmentUuid/log-forwarding-destinations/$destId")
         );
     }
 
     /**
      * Disables a log forwarding destination.
      *
-     * @param  string $environmentUuid
-     * @param  int    $destId
+     * @param string $environmentUuid
+     * @param int $destId
+     *
      * @return OperationResponse
      */
-    public function disable($environmentUuid, $destId): OperationResponse
+    public function disable(string $environmentUuid, int $destId): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/log-forwarding-destinations/${destId}/actions/disable"
+                "/environments/$environmentUuid/log-forwarding-destinations/$destId/actions/disable"
             )
         );
     }
@@ -109,16 +114,17 @@ class LogForwardingDestinations extends CloudApiBase implements CloudApiInterfac
     /**
      * Enables a log forwarding destination.
      *
-     * @param  string $environmentUuid
-     * @param  int    $destId
+     * @param string $environmentUuid
+     * @param int $destId
+     *
      * @return OperationResponse
      */
-    public function enable($environmentUuid, $destId): OperationResponse
+    public function enable(string $environmentUuid, int $destId): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/log-forwarding-destinations/${destId}/actions/enable"
+                "/environments/$environmentUuid/log-forwarding-destinations/$destId/actions/enable"
             )
         );
     }
@@ -126,16 +132,17 @@ class LogForwardingDestinations extends CloudApiBase implements CloudApiInterfac
     /**
      * Updates a log forwarding destination.
      *
-     * @param  string  $environmentUuid
-     * @param  int     $destId
-     * @param  string  $label
-     * @param  mixed[] $sources
-     * @param  string  $consumer
-     * @param  mixed[] $creds
-     * @param  string  $address
+     * @param string $environmentUuid
+     * @param int $destId
+     * @param string $label
+     * @param mixed[] $sources
+     * @param string $consumer
+     * @param mixed[] $creds
+     * @param string $address
+     *
      * @return OperationResponse
      */
-    public function update($environmentUuid, $destId, $label, $sources, $consumer, $creds, $address): OperationResponse
+    public function update(string $environmentUuid, int $destId, string $label, array $sources, string $consumer, array $creds, string $address): OperationResponse
     {
         $options = [
             'json' => [
@@ -143,14 +150,14 @@ class LogForwardingDestinations extends CloudApiBase implements CloudApiInterfac
                 'sources' => $sources,
                 'consumer' => $consumer,
                 'credentials' => $creds,
-                'address' => $address
+                'address' => $address,
             ],
         ];
 
         return new OperationResponse(
             $this->client->request(
                 'put',
-                "/environments/${environmentUuid}/log-forwarding-destinations/${destId}",
+                "/environments/$environmentUuid/log-forwarding-destinations/$destId",
                 $options
             )
         );

--- a/src/Endpoints/Logs.php
+++ b/src/Endpoints/Logs.php
@@ -2,11 +2,9 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\EnvironmentResponse;
-use AcquiaCloudApi\Response\EnvironmentsResponse;
-use AcquiaCloudApi\Response\LogstreamResponse;
-use AcquiaCloudApi\Response\LogsResponse;
 use AcquiaCloudApi\Response\LogResponse;
+use AcquiaCloudApi\Response\LogsResponse;
+use AcquiaCloudApi\Response\LogstreamResponse;
 use AcquiaCloudApi\Response\OperationResponse;
 use Psr\Http\Message\StreamInterface;
 
@@ -15,57 +13,61 @@ use Psr\Http\Message\StreamInterface;
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Logs extends CloudApiBase implements CloudApiInterface
+class Logs extends CloudApiBase
 {
     /**
      * Returns a list of log files available for download.
      *
-     * @param  string $environmentUuid
+     * @param string $environmentUuid
+     *
      * @return LogsResponse<LogResponse>
      */
-    public function getAll($environmentUuid): LogsResponse
+    public function getAll(string $environmentUuid): LogsResponse
     {
         return new LogsResponse(
-            $this->client->request('get', "/environments/${environmentUuid}/logs")
+            $this->client->request('get', "/environments/$environmentUuid/logs")
         );
     }
 
     /**
      * Downloads a log file.
      *
-     * @param  string $environmentUuid
-     * @param  string $logType
+     * @param string $environmentUuid
+     * @param string $logType
+     *
      * @return StreamInterface
      */
-    public function download($environmentUuid, $logType): StreamInterface
+    public function download(string $environmentUuid, string $logType): StreamInterface
     {
-        return $this->client->stream('get', "/environments/${environmentUuid}/logs/${logType}");
-    }
-
-    /**
-     * Creates a log file snapshot.
-     *
-     * @param  string $environmentUuid
-     * @param  string $logType
-     * @return OperationResponse
-     */
-    public function snapshot($environmentUuid, $logType): OperationResponse
-    {
-        return new OperationResponse(
-            $this->client->request('post', "/environments/${environmentUuid}/logs/${logType}")
-        );
+        return $this->client->stream('get', "/environments/$environmentUuid/logs/$logType");
     }
 
     /**
      * Returns logstream WSS stream information.
      *
-     * @param  string $environmentUuid
+     * @param string $environmentUuid
+     *
      * @return LogstreamResponse
      */
-    public function stream($environmentUuid): LogstreamResponse
+    public function stream(string $environmentUuid): LogstreamResponse
     {
         return new LogstreamResponse(
-            $this->client->request('get', "/environments/${environmentUuid}/logstream")
+            $this->client->request('get', "/environments/$environmentUuid/logstream")
+        );
+    }
+
+    /**
+     * Creates a log file snapshot.
+     *
+     * @param string $environmentUuid
+     * @param string $logType
+     *
+     * @return OperationResponse
+     */
+    public function snapshot(string $environmentUuid, string $logType): OperationResponse
+    {
+        return new OperationResponse(
+            $this->client->request('post', "/environments/$environmentUuid/logs/$logType")
         );
     }
 }

--- a/src/Endpoints/Metrics.php
+++ b/src/Endpoints/Metrics.php
@@ -2,28 +2,29 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\MetricsResponse;
 use AcquiaCloudApi\Response\MetricResponse;
+use AcquiaCloudApi\Response\MetricsResponse;
 
 /**
  * Class Metrics
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Metrics extends CloudApiBase implements CloudApiInterface
+class Metrics extends CloudApiBase
 {
     /**
      * Retrieves aggregate usage data for an application.
      *
-     * @param  string $applicationUuid
+     * @param string $applicationUuid
+     *
      * @return MetricsResponse<MetricResponse>
      */
-    public function getAggregateData($applicationUuid): MetricsResponse
+    public function getAggregateData(string $applicationUuid): MetricsResponse
     {
         return new MetricsResponse(
             $this->client->request(
                 'get',
-                "/applications/${applicationUuid}/metrics/usage/data"
+                "/applications/$applicationUuid/metrics/usage/data"
             )
         );
     }
@@ -31,16 +32,17 @@ class Metrics extends CloudApiBase implements CloudApiInterface
     /**
      * Retrieves aggregate usage metric data for an application.
      *
-     * @param  string $applicationUuid
-     * @param  string $usageMetric
+     * @param string $applicationUuid
+     * @param string $usageMetric
+     *
      * @return MetricResponse
      */
-    public function getAggregateUsageMetrics($applicationUuid, $usageMetric): MetricResponse
+    public function getAggregateUsageMetrics(string $applicationUuid, string $usageMetric): MetricResponse
     {
         return new MetricResponse(
             $this->client->request(
                 'get',
-                "/applications/${applicationUuid}/metrics/usage/${usageMetric}"
+                "/applications/$applicationUuid/metrics/usage/$usageMetric"
             )
         );
     }
@@ -48,15 +50,16 @@ class Metrics extends CloudApiBase implements CloudApiInterface
     /**
      * Retrieves usage data for an application, broken down by environment.
      *
-     * @param  string $applicationUuid
+     * @param string $applicationUuid
+     *
      * @return MetricsResponse<MetricResponse>
      */
-    public function getDataByEnvironment($applicationUuid): MetricsResponse
+    public function getDataByEnvironment(string $applicationUuid): MetricsResponse
     {
         return new MetricsResponse(
             $this->client->request(
                 'get',
-                "/applications/${applicationUuid}/metrics/usage/data-by-environment"
+                "/applications/$applicationUuid/metrics/usage/data-by-environment"
             )
         );
     }
@@ -64,15 +67,16 @@ class Metrics extends CloudApiBase implements CloudApiInterface
     /**
      * Retrieves views data for an application, broken down by environment.
      *
-     * @param  string $applicationUuid
+     * @param string $applicationUuid
+     *
      * @return MetricsResponse<MetricResponse>
      */
-    public function getViewsByEnvironment($applicationUuid): MetricsResponse
+    public function getViewsByEnvironment(string $applicationUuid): MetricsResponse
     {
         return new MetricsResponse(
             $this->client->request(
                 'get',
-                "/applications/${applicationUuid}/metrics/usage/views-by-environment"
+                "/applications/$applicationUuid/metrics/usage/views-by-environment"
             )
         );
     }
@@ -80,32 +84,35 @@ class Metrics extends CloudApiBase implements CloudApiInterface
     /**
      * Retrieves visits data for an application, broken down by environment.
      *
-     * @param  string $applicationUuid
+     * @param string $applicationUuid
+     *
      * @return MetricsResponse<MetricResponse>
      */
-    public function getVisitsByEnvironment($applicationUuid): MetricsResponse
+    public function getVisitsByEnvironment(string $applicationUuid): MetricsResponse
     {
         return new MetricsResponse(
             $this->client->request(
                 'get',
-                "/applications/${applicationUuid}/metrics/usage/visits-by-environment"
+                "/applications/$applicationUuid/metrics/usage/visits-by-environment"
             )
         );
     }
 
     /**
-     * Returns StackMetrics data for the metrics specified in the filter paramater
+     * Returns StackMetrics data for the metrics specified in the filter
+     * paramater
      * (e.g., apache-access, web-cpu).
      *
-     * @param  string $environmentUuid
+     * @param string $environmentUuid
+     *
      * @return MetricsResponse<MetricResponse>
      */
-    public function getStackMetricsData($environmentUuid): MetricsResponse
+    public function getStackMetricsData(string $environmentUuid): MetricsResponse
     {
         return new MetricsResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/metrics/stackmetrics/data"
+                "/environments/$environmentUuid/metrics/stackmetrics/data"
             )
         );
     }
@@ -113,16 +120,17 @@ class Metrics extends CloudApiBase implements CloudApiInterface
     /**
      * Returns StackMetrics data for the metric (e.g., apache-access).
      *
-     * @param  string $environmentUuid
-     * @param  string $metricType
+     * @param string $environmentUuid
+     * @param string $metricType
+     *
      * @return MetricResponse
      */
-    public function getStackMetricsDataByMetric($environmentUuid, $metricType): MetricResponse
+    public function getStackMetricsDataByMetric(string $environmentUuid, string $metricType): MetricResponse
     {
         return new MetricResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/metrics/stackmetrics/${metricType}"
+                "/environments/$environmentUuid/metrics/stackmetrics/$metricType"
             )
         );
     }

--- a/src/Endpoints/Notifications.php
+++ b/src/Endpoints/Notifications.php
@@ -10,20 +10,21 @@ use AcquiaCloudApi\Response\NotificationsResponse;
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Notifications extends CloudApiBase implements CloudApiInterface
+class Notifications extends CloudApiBase
 {
     /**
      * Returns details about a notification.
      *
-     * @param  string $notificationUuid
+     * @param string $notificationUuid
+     *
      * @return NotificationResponse
      */
-    public function get($notificationUuid): NotificationResponse
+    public function get(string $notificationUuid): NotificationResponse
     {
         return new NotificationResponse(
             $this->client->request(
                 'get',
-                "/notifications/${notificationUuid}"
+                "/notifications/$notificationUuid"
             )
         );
     }
@@ -31,15 +32,16 @@ class Notifications extends CloudApiBase implements CloudApiInterface
     /**
      * Returns a list of notifications.
      *
-     * @param  string $applicationUuid
+     * @param string $applicationUuid
+     *
      * @return NotificationsResponse<NotificationResponse>
      */
-    public function getAll($applicationUuid): NotificationsResponse
+    public function getAll(string $applicationUuid): NotificationsResponse
     {
         return new NotificationsResponse(
             $this->client->request(
                 'get',
-                "/applications/${applicationUuid}/notifications"
+                "/applications/$applicationUuid/notifications"
             )
         );
     }

--- a/src/Endpoints/Organizations.php
+++ b/src/Endpoints/Organizations.php
@@ -2,24 +2,24 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\ApplicationsResponse;
 use AcquiaCloudApi\Response\ApplicationResponse;
-use AcquiaCloudApi\Response\InvitationsResponse;
+use AcquiaCloudApi\Response\ApplicationsResponse;
 use AcquiaCloudApi\Response\InvitationResponse;
-use AcquiaCloudApi\Response\MembersResponse;
+use AcquiaCloudApi\Response\InvitationsResponse;
 use AcquiaCloudApi\Response\MemberResponse;
-use AcquiaCloudApi\Response\OrganizationsResponse;
-use AcquiaCloudApi\Response\OrganizationResponse;
-use AcquiaCloudApi\Response\TeamsResponse;
-use AcquiaCloudApi\Response\TeamResponse;
+use AcquiaCloudApi\Response\MembersResponse;
 use AcquiaCloudApi\Response\OperationResponse;
+use AcquiaCloudApi\Response\OrganizationResponse;
+use AcquiaCloudApi\Response\OrganizationsResponse;
+use AcquiaCloudApi\Response\TeamResponse;
+use AcquiaCloudApi\Response\TeamsResponse;
 
 /**
  * Class Organizations
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Organizations extends CloudApiBase implements CloudApiInterface
+class Organizations extends CloudApiBase
 {
     /**
      * Show all organizations.
@@ -35,95 +35,102 @@ class Organizations extends CloudApiBase implements CloudApiInterface
      * Show all applications in an organization.
      *
      * @param string $organizationUuid
+     *
      * @return ApplicationsResponse<ApplicationResponse>
      */
-    public function getApplications($organizationUuid): ApplicationsResponse
+    public function getApplications(string $organizationUuid): ApplicationsResponse
     {
         return new ApplicationsResponse(
-            $this->client->request('get', "/organizations/${organizationUuid}/applications")
+            $this->client->request('get', "/organizations/$organizationUuid/applications")
         );
     }
 
     /**
      * Show all members of an organization.
      *
-     * @param  string $organizationUuid
+     * @param string $organizationUuid
+     *
      * @return MembersResponse<MemberResponse>
      */
-    public function getMembers($organizationUuid): MembersResponse
+    public function getMembers(string $organizationUuid): MembersResponse
     {
         return new MembersResponse(
-            $this->client->request('get', "/organizations/${organizationUuid}/members")
+            $this->client->request('get', "/organizations/$organizationUuid/members")
         );
     }
 
     /**
      * Returns the user profile of this organization member.
      *
-     * @param  string $organizationUuid
-     * @param  string $memberUuid
+     * @param string $organizationUuid
+     * @param string $memberUuid
+     *
      * @return MemberResponse
      */
-    public function getMember($organizationUuid, $memberUuid): MemberResponse
+    public function getMember(string $organizationUuid, string $memberUuid): MemberResponse
     {
         return new MemberResponse(
-            $this->client->request('get', "/organizations/${organizationUuid}/members/${memberUuid}")
+            $this->client->request('get', "/organizations/$organizationUuid/members/$memberUuid")
         );
     }
 
     /**
      * Show all admins of an organization.
      *
-     * @param  string $organizationUuid
+     * @param string $organizationUuid
+     *
      * @return MembersResponse<MemberResponse>
      */
-    public function getAdmins($organizationUuid): MembersResponse
+    public function getAdmins(string $organizationUuid): MembersResponse
     {
         return new MembersResponse(
-            $this->client->request('get', "/organizations/${organizationUuid}/admins")
+            $this->client->request('get', "/organizations/$organizationUuid/admins")
         );
     }
 
     /**
      * Returns the user profile of this organization administrator.
      *
-     * @param  string $organizationUuid
-     * @param  string $memberUuid
+     * @param string $organizationUuid
+     * @param string $memberUuid
+     *
      * @return MemberResponse
      */
-    public function getAdmin($organizationUuid, $memberUuid): MemberResponse
+    public function getAdmin(string $organizationUuid, string $memberUuid): MemberResponse
     {
         return new MemberResponse(
-            $this->client->request('get', "/organizations/${organizationUuid}/admins/${memberUuid}")
+            $this->client->request('get', "/organizations/$organizationUuid/admins/$memberUuid")
         );
     }
 
     /**
      * Show all members invited to an organization.
      *
-     * @param  string $organizationUuid
+     * @param string $organizationUuid
+     *
      * @return InvitationsResponse<InvitationResponse>
      */
-    public function getMemberInvitations($organizationUuid): InvitationsResponse
+    public function getMemberInvitations(string $organizationUuid): InvitationsResponse
     {
         return new InvitationsResponse(
-            $this->client->request('get', "/organizations/${organizationUuid}/team-invites")
+            $this->client->request('get', "/organizations/$organizationUuid/team-invites")
         );
     }
 
     /**
      * Delete a member from an organization.
      *
-     * @param  string $organizationUuid
-     * @param  string $memberUuid
+     * @param string $organizationUuid
+     * @param string $memberUuid
+     *
      * @return OperationResponse
      */
-    public function deleteMember($organizationUuid, $memberUuid): OperationResponse
+    public function deleteMember(string $organizationUuid, string $memberUuid): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'delete',
-                "/organizations/${organizationUuid}/members/${memberUuid}"
+                "/organizations/$organizationUuid/members/$memberUuid"
             )
         );
     }
@@ -132,14 +139,15 @@ class Organizations extends CloudApiBase implements CloudApiInterface
      * Leave an organization.
      *
      * @param string $organizationUuid
+     *
      * @return OperationResponse
      */
-    public function leaveOrganization($organizationUuid): OperationResponse
+    public function leaveOrganization(string $organizationUuid): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/organizations/${organizationUuid}/actions/leave"
+                "/organizations/$organizationUuid/actions/leave"
             )
         );
     }
@@ -149,9 +157,10 @@ class Organizations extends CloudApiBase implements CloudApiInterface
      *
      * @param string $organizationUuid
      * @param string $newOwnerUuid
+     *
      * @return OperationResponse
      */
-    public function changeOwner($organizationUuid, $newOwnerUuid): OperationResponse
+    public function changeOwner(string $organizationUuid, string $newOwnerUuid): OperationResponse
     {
         $options = [
             'json' => [
@@ -161,7 +170,7 @@ class Organizations extends CloudApiBase implements CloudApiInterface
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/organizations/${organizationUuid}/actions/change-owner",
+                "/organizations/$organizationUuid/actions/change-owner",
                 $options
             )
         );
@@ -170,24 +179,26 @@ class Organizations extends CloudApiBase implements CloudApiInterface
     /**
      * Show all teams in an organization.
      *
-     * @param  string $organizationUuid
+     * @param string $organizationUuid
+     *
      * @return TeamsResponse<TeamResponse>
      */
-    public function getTeams($organizationUuid): TeamsResponse
+    public function getTeams(string $organizationUuid): TeamsResponse
     {
         return new TeamsResponse(
-            $this->client->request('get', "/organizations/${organizationUuid}/teams")
+            $this->client->request('get', "/organizations/$organizationUuid/teams")
         );
     }
 
     /**
      * Invites a user to become admin of an organization.
      *
-     * @param  string $organizationUuid
-     * @param  string $email
+     * @param string $organizationUuid
+     * @param string $email
+     *
      * @return OperationResponse
      */
-    public function inviteAdmin($organizationUuid, $email): OperationResponse
+    public function inviteAdmin(string $organizationUuid, string $email): OperationResponse
     {
         $options = [
             'json' => [
@@ -196,7 +207,7 @@ class Organizations extends CloudApiBase implements CloudApiInterface
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/organizations/${organizationUuid}/admin-invites", $options)
+            $this->client->request('post', "/organizations/$organizationUuid/admin-invites", $options)
         );
     }
 }

--- a/src/Endpoints/Permissions.php
+++ b/src/Endpoints/Permissions.php
@@ -2,15 +2,15 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\PermissionsResponse;
 use AcquiaCloudApi\Response\PermissionResponse;
+use AcquiaCloudApi\Response\PermissionsResponse;
 
 /**
  * Class Permissions
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Permissions extends CloudApiBase implements CloudApiInterface
+class Permissions extends CloudApiBase
 {
     /**
      * Show all available permissions.

--- a/src/Endpoints/Roles.php
+++ b/src/Endpoints/Roles.php
@@ -2,53 +2,56 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\RolesResponse;
-use AcquiaCloudApi\Response\RoleResponse;
 use AcquiaCloudApi\Response\OperationResponse;
+use AcquiaCloudApi\Response\RoleResponse;
+use AcquiaCloudApi\Response\RolesResponse;
 
 /**
  * Class Roles
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Roles extends CloudApiBase implements CloudApiInterface
+class Roles extends CloudApiBase
 {
     /**
      * Show all roles in an organization.
      *
-     * @param  string $organizationUuid
+     * @param string $organizationUuid
+     *
      * @return RolesResponse<RoleResponse>
      */
-    public function getAll($organizationUuid): RolesResponse
+    public function getAll(string $organizationUuid): RolesResponse
     {
         return new RolesResponse(
-            $this->client->request('get', "/organizations/${organizationUuid}/roles")
+            $this->client->request('get', "/organizations/$organizationUuid/roles")
         );
     }
 
     /**
      * Return details about a specific role.
      *
-     * @param  string $roleUuid
+     * @param string $roleUuid
+     *
      * @return RoleResponse
      */
-    public function get($roleUuid): RoleResponse
+    public function get(string $roleUuid): RoleResponse
     {
         return new RoleResponse(
-            $this->client->request('get', "/roles/${roleUuid}")
+            $this->client->request('get', "/roles/$roleUuid")
         );
     }
 
     /**
      * Create a new role.
      *
-     * @param  string        $organizationUuid
-     * @param  string        $name
-     * @param  array<string> $permissions
-     * @param  null|string $description
+     * @param string $organizationUuid
+     * @param string $name
+     * @param array<string> $permissions
+     * @param string|null $description
+     *
      * @return OperationResponse
      */
-    public function create($organizationUuid, $name, array $permissions, $description = null): OperationResponse
+    public function create(string $organizationUuid, string $name, array $permissions, string $description = null): OperationResponse
     {
         $options = [
             'json' => [
@@ -59,18 +62,19 @@ class Roles extends CloudApiBase implements CloudApiInterface
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/organizations/${organizationUuid}/roles", $options)
+            $this->client->request('post', "/organizations/$organizationUuid/roles", $options)
         );
     }
 
     /**
      * Update the permissions associated with a role.
      *
-     * @param  string        $roleUuid
-     * @param  array<string> $permissions
+     * @param string $roleUuid
+     * @param array<string> $permissions
+     *
      * @return OperationResponse
      */
-    public function update($roleUuid, array $permissions): OperationResponse
+    public function update(string $roleUuid, array $permissions): OperationResponse
     {
         $options = [
             'json' => [
@@ -79,18 +83,19 @@ class Roles extends CloudApiBase implements CloudApiInterface
         ];
 
         return new OperationResponse(
-            $this->client->request('put', "/roles/${roleUuid}", $options)
+            $this->client->request('put', "/roles/$roleUuid", $options)
         );
     }
 
     /**
      * Delete a role.
      *
-     * @param  string $roleUuid
+     * @param string $roleUuid
+     *
      * @return OperationResponse
      */
-    public function delete($roleUuid): OperationResponse
+    public function delete(string $roleUuid): OperationResponse
     {
-        return new OperationResponse($this->client->request('delete', "/roles/${roleUuid}"));
+        return new OperationResponse($this->client->request('delete', "/roles/$roleUuid"));
     }
 }

--- a/src/Endpoints/Servers.php
+++ b/src/Endpoints/Servers.php
@@ -3,29 +3,30 @@
 namespace AcquiaCloudApi\Endpoints;
 
 use AcquiaCloudApi\Response\OperationResponse;
-use AcquiaCloudApi\Response\ServersResponse;
 use AcquiaCloudApi\Response\ServerResponse;
+use AcquiaCloudApi\Response\ServersResponse;
 
 /**
  * Class Servers
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Servers extends CloudApiBase implements CloudApiInterface
+class Servers extends CloudApiBase
 {
     /**
      * Gets information about a single server.
      *
-     * @param  string $environmentUuid
-     * @param  string $serverId
+     * @param string $environmentUuid
+     * @param string $serverId
+     *
      * @return ServerResponse
      */
-    public function get($environmentUuid, $serverId): ServerResponse
+    public function get(string $environmentUuid, string $serverId): ServerResponse
     {
         return new ServerResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/servers/${serverId}"
+                "/environments/$environmentUuid/servers/$serverId"
             )
         );
     }
@@ -33,17 +34,18 @@ class Servers extends CloudApiBase implements CloudApiInterface
     /**
      * Modifies configuration settings for a server.
      *
-     * @param  string  $environmentUuid
-     * @param  string  $serverId
-     * @param  mixed[] $config
+     * @param string $environmentUuid
+     * @param string $serverId
+     * @param mixed[] $config
+     *
      * @return OperationResponse
      */
-    public function update($environmentUuid, $serverId, array $config): OperationResponse
+    public function update(string $environmentUuid, string $serverId, array $config): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'put',
-                "/environments/${environmentUuid}/servers/${serverId}",
+                "/environments/$environmentUuid/servers/$serverId",
                 $config
             )
         );
@@ -52,15 +54,16 @@ class Servers extends CloudApiBase implements CloudApiInterface
     /**
      * Show all servers associated with an environment.
      *
-     * @param  string $environmentUuid
+     * @param string $environmentUuid
+     *
      * @return ServersResponse<ServerResponse>
      */
-    public function getAll($environmentUuid): ServersResponse
+    public function getAll(string $environmentUuid): ServersResponse
     {
         return new ServersResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/servers"
+                "/environments/$environmentUuid/servers"
             )
         );
     }

--- a/src/Endpoints/SshKeys.php
+++ b/src/Endpoints/SshKeys.php
@@ -2,16 +2,16 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\SshKeysResponse;
-use AcquiaCloudApi\Response\SshKeyResponse;
 use AcquiaCloudApi\Response\OperationResponse;
+use AcquiaCloudApi\Response\SshKeyResponse;
+use AcquiaCloudApi\Response\SshKeysResponse;
 
 /**
  * Class SshKeys
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class SshKeys extends CloudApiBase implements CloudApiInterface
+class SshKeys extends CloudApiBase
 {
     /**
      * Returns a list of SSL keys.
@@ -31,15 +31,16 @@ class SshKeys extends CloudApiBase implements CloudApiInterface
     /**
      * Returns a specific key by key ID.
      *
-     * @param  string $keyId
+     * @param string $keyId
+     *
      * @return SshKeyResponse
      */
-    public function get($keyId): SshKeyResponse
+    public function get(string $keyId): SshKeyResponse
     {
         return new SshKeyResponse(
             $this->client->request(
                 'get',
-                "/account/ssh-keys/${keyId}"
+                "/account/ssh-keys/$keyId"
             )
         );
     }
@@ -47,17 +48,18 @@ class SshKeys extends CloudApiBase implements CloudApiInterface
     /**
      * Create an SSH key.
      *
-     * @param  string $label
-     * @param  string $public_key
+     * @param string $label
+     * @param string $public_key
+     *
      * @return OperationResponse
      */
-    public function create($label, $public_key): OperationResponse
+    public function create(string $label, string $public_key): OperationResponse
     {
 
         $options = [
             'json' => [
                 'label' => $label,
-                'public_key' => $public_key
+                'public_key' => $public_key,
             ],
         ];
 
@@ -69,13 +71,14 @@ class SshKeys extends CloudApiBase implements CloudApiInterface
     /**
      * Delete a specific key by ID.
      *
-     * @param  string  $keyId
+     * @param string $keyId
+     *
      * @return OperationResponse
      */
-    public function delete($keyId): OperationResponse
+    public function delete(string $keyId): OperationResponse
     {
         return new OperationResponse(
-            $this->client->request('delete', "/account/ssh-keys/${keyId}")
+            $this->client->request('delete', "/account/ssh-keys/$keyId")
         );
     }
 }

--- a/src/Endpoints/SslCertificates.php
+++ b/src/Endpoints/SslCertificates.php
@@ -2,29 +2,30 @@
 
 namespace AcquiaCloudApi\Endpoints;
 
-use AcquiaCloudApi\Response\SslCertificatesResponse;
-use AcquiaCloudApi\Response\SslCertificateResponse;
 use AcquiaCloudApi\Response\OperationResponse;
+use AcquiaCloudApi\Response\SslCertificateResponse;
+use AcquiaCloudApi\Response\SslCertificatesResponse;
 
 /**
  * Class SslCertificates
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class SslCertificates extends CloudApiBase implements CloudApiInterface
+class SslCertificates extends CloudApiBase
 {
     /**
      * Returns a list of SSL certificates.
      *
-     * @param  string $environmentUuid The environment ID
+     * @param string $environmentUuid The environment ID
+     *
      * @return SslCertificatesResponse<SslCertificateResponse>
      */
-    public function getAll($environmentUuid): SslCertificatesResponse
+    public function getAll(string $environmentUuid): SslCertificatesResponse
     {
         return new SslCertificatesResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/ssl/certificates"
+                "/environments/$environmentUuid/ssl/certificates"
             )
         );
     }
@@ -32,16 +33,17 @@ class SslCertificates extends CloudApiBase implements CloudApiInterface
     /**
      * Returns a specific certificate by certificate ID.
      *
-     * @param  string $environmentUuid The environment ID
-     * @param  int    $certificateId
+     * @param string $environmentUuid The environment ID
+     * @param int $certificateId
+     *
      * @return SslCertificateResponse
      */
-    public function get($environmentUuid, $certificateId): SslCertificateResponse
+    public function get(string $environmentUuid, int $certificateId): SslCertificateResponse
     {
         return new SslCertificateResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/ssl/certificates/${certificateId}"
+                "/environments/$environmentUuid/ssl/certificates/$certificateId"
             )
         );
     }
@@ -49,16 +51,17 @@ class SslCertificates extends CloudApiBase implements CloudApiInterface
     /**
      * Install an SSL certificate.
      *
-     * @param  string $envUuid
-     * @param  string $label
-     * @param  string $cert
-     * @param  string $key
-     * @param  string $ca
-     * @param  int    $csr
-     * @param  bool   $legacy
+     * @param string $envUuid
+     * @param string $label
+     * @param string $cert
+     * @param string $key
+     * @param string|null $ca
+     * @param int|null $csr
+     * @param bool $legacy
+     *
      * @return OperationResponse
      */
-    public function create($envUuid, $label, $cert, $key, $ca = null, $csr = null, $legacy = false): OperationResponse
+    public function create(string $envUuid, string $label, string $cert, string $key, string $ca = null, int $csr = null, bool $legacy = false): OperationResponse
     {
 
         $options = [
@@ -68,42 +71,44 @@ class SslCertificates extends CloudApiBase implements CloudApiInterface
                 'private_key' => $key,
                 'ca_certificates' => $ca,
                 'csr_id' => $csr,
-                'legacy' => $legacy
+                'legacy' => $legacy,
             ],
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/environments/${envUuid}/ssl/certificates", $options)
+            $this->client->request('post', "/environments/$envUuid/ssl/certificates", $options)
         );
     }
 
     /**
      * Delete a specific certificate by ID.
      *
-     * @param  string $environmentUuid
-     * @param  int    $certificateId
+     * @param string $environmentUuid
+     * @param int $certificateId
+     *
      * @return OperationResponse
      */
-    public function delete($environmentUuid, $certificateId): OperationResponse
+    public function delete(string $environmentUuid, int $certificateId): OperationResponse
     {
         return new OperationResponse(
-            $this->client->request('delete', "/environments/${environmentUuid}/ssl/certificates/${certificateId}")
+            $this->client->request('delete', "/environments/$environmentUuid/ssl/certificates/$certificateId")
         );
     }
 
     /**
      * Deactivates an active SSL certificate.
      *
-     * @param  string $environmentUuid
-     * @param  int    $certificateId
+     * @param string $environmentUuid
+     * @param int $certificateId
+     *
      * @return OperationResponse
      */
-    public function disable($environmentUuid, $certificateId): OperationResponse
+    public function disable(string $environmentUuid, int $certificateId): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/ssl/certificates/${certificateId}/actions/deactivate"
+                "/environments/$environmentUuid/ssl/certificates/$certificateId/actions/deactivate"
             )
         );
     }
@@ -111,16 +116,17 @@ class SslCertificates extends CloudApiBase implements CloudApiInterface
     /**
      * Activates an SSL certificate.
      *
-     * @param  string $environmentUuid
-     * @param  int    $certificateId
+     * @param string $environmentUuid
+     * @param int $certificateId
+     *
      * @return OperationResponse
      */
-    public function enable($environmentUuid, $certificateId): OperationResponse
+    public function enable(string $environmentUuid, int $certificateId): OperationResponse
     {
         return new OperationResponse(
             $this->client->request(
                 'post',
-                "/environments/${environmentUuid}/ssl/certificates/${certificateId}/actions/activate"
+                "/environments/$environmentUuid/ssl/certificates/$certificateId/actions/activate"
             )
         );
     }

--- a/src/Endpoints/Subscriptions.php
+++ b/src/Endpoints/Subscriptions.php
@@ -6,7 +6,7 @@ use AcquiaCloudApi\Response\OperationResponse;
 use AcquiaCloudApi\Response\SubscriptionResponse;
 use AcquiaCloudApi\Response\SubscriptionsResponse;
 
-class Subscriptions extends CloudApiBase implements CloudApiInterface
+class Subscriptions extends CloudApiBase
 {
     /**
      * Shows all Subscriptions.
@@ -21,15 +21,16 @@ class Subscriptions extends CloudApiBase implements CloudApiInterface
     /**
      * Shows information about an subscription.
      *
-     * @param  string $subscriptionUuid
+     * @param string $subscriptionUuid
+     *
      * @return SubscriptionResponse
      */
-    public function get($subscriptionUuid): SubscriptionResponse
+    public function get(string $subscriptionUuid): SubscriptionResponse
     {
         return new SubscriptionResponse(
             $this->client->request(
                 'get',
-                "/subscriptions/${subscriptionUuid}"
+                "/subscriptions/$subscriptionUuid"
             )
         );
     }
@@ -37,11 +38,12 @@ class Subscriptions extends CloudApiBase implements CloudApiInterface
     /**
      * Renames an subscription.
      *
-     * @param  string $subscriptionUuid
-     * @param  string $name
+     * @param string $subscriptionUuid
+     * @param string $name
+     *
      * @return OperationResponse
      */
-    public function rename($subscriptionUuid, $name): OperationResponse
+    public function rename(string $subscriptionUuid, string $name): OperationResponse
     {
 
         $options = [
@@ -53,7 +55,7 @@ class Subscriptions extends CloudApiBase implements CloudApiInterface
         return new OperationResponse(
             $this->client->request(
                 'put',
-                "/subscriptions/${subscriptionUuid}",
+                "/subscriptions/$subscriptionUuid",
                 $options
             )
         );

--- a/src/Endpoints/Teams.php
+++ b/src/Endpoints/Teams.php
@@ -4,25 +4,26 @@ namespace AcquiaCloudApi\Endpoints;
 
 use AcquiaCloudApi\Response\ApplicationResponse;
 use AcquiaCloudApi\Response\ApplicationsResponse;
-use AcquiaCloudApi\Response\TeamsResponse;
-use AcquiaCloudApi\Response\TeamResponse;
 use AcquiaCloudApi\Response\OperationResponse;
+use AcquiaCloudApi\Response\TeamResponse;
+use AcquiaCloudApi\Response\TeamsResponse;
 
 /**
  * Class Teams
  *
  * @package AcquiaCloudApi\CloudApi
  */
-class Teams extends CloudApiBase implements CloudApiInterface
+class Teams extends CloudApiBase
 {
     /**
      * Create a new team.
      *
-     * @param  string $organizationUuid
-     * @param  string $name
+     * @param string $organizationUuid
+     * @param string $name
+     *
      * @return OperationResponse
      */
-    public function create($organizationUuid, $name): OperationResponse
+    public function create(string $organizationUuid, string $name): OperationResponse
     {
         $options = [
             'json' => [
@@ -31,7 +32,7 @@ class Teams extends CloudApiBase implements CloudApiInterface
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/organizations/${organizationUuid}/teams", $options)
+            $this->client->request('post', "/organizations/$organizationUuid/teams", $options)
         );
     }
 
@@ -50,11 +51,12 @@ class Teams extends CloudApiBase implements CloudApiInterface
     /**
      * Rename an existing team.
      *
-     * @param  string $teamUuid
-     * @param  string $name
+     * @param string $teamUuid
+     * @param string $name
+     *
      * @return OperationResponse
      */
-    public function rename($teamUuid, $name): OperationResponse
+    public function rename(string $teamUuid, string $name): OperationResponse
     {
         $options = [
             'json' => [
@@ -63,7 +65,7 @@ class Teams extends CloudApiBase implements CloudApiInterface
         ];
 
         return new OperationResponse(
-            $this->client->request('put', "/teams/${teamUuid}", $options)
+            $this->client->request('put', "/teams/$teamUuid", $options)
         );
     }
 
@@ -71,24 +73,26 @@ class Teams extends CloudApiBase implements CloudApiInterface
     /**
      * Delete a team.
      *
-     * @param  string $teamUuid
+     * @param string $teamUuid
+     *
      * @return OperationResponse
      */
-    public function delete($teamUuid): OperationResponse
+    public function delete(string $teamUuid): OperationResponse
     {
         return new OperationResponse(
-            $this->client->request('delete', "/teams/${teamUuid}")
+            $this->client->request('delete', "/teams/$teamUuid")
         );
     }
 
     /**
      * Add an application to a team.
      *
-     * @param  string $teamUuid
-     * @param  string $applicationUuid
+     * @param string $teamUuid
+     * @param string $applicationUuid
+     *
      * @return OperationResponse
      */
-    public function addApplication($teamUuid, $applicationUuid): OperationResponse
+    public function addApplication(string $teamUuid, string $applicationUuid): OperationResponse
     {
         $options = [
             'json' => [
@@ -97,42 +101,44 @@ class Teams extends CloudApiBase implements CloudApiInterface
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/teams/${teamUuid}/applications", $options)
+            $this->client->request('post', "/teams/$teamUuid/applications", $options)
         );
     }
 
     /**
      * Invites a user to join a team.
      *
-     * @param  string   $teamUuid
-     * @param  string   $email
-     * @param  string[] $roles
+     * @param string $teamUuid
+     * @param string $email
+     * @param string[] $roles
+     *
      * @return OperationResponse
      */
-    public function invite($teamUuid, $email, $roles): OperationResponse
+    public function invite(string $teamUuid, string $email, array $roles): OperationResponse
     {
         $options = [
             'json' => [
                 'email' => $email,
-                'roles' => $roles
+                'roles' => $roles,
             ],
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/teams/${teamUuid}/invites", $options)
+            $this->client->request('post', "/teams/$teamUuid/invites", $options)
         );
     }
 
     /**
      * Show all applications associated with a team.
      *
-     * @param  string $teamUuid
+     * @param string $teamUuid
+     *
      * @return ApplicationsResponse<ApplicationResponse>
      */
-    public function getApplications($teamUuid): ApplicationsResponse
+    public function getApplications(string $teamUuid): ApplicationsResponse
     {
         return new ApplicationsResponse(
-            $this->client->request('get', "/teams/${teamUuid}/applications")
+            $this->client->request('get', "/teams/$teamUuid/applications")
         );
     }
 }

--- a/src/Endpoints/Variables.php
+++ b/src/Endpoints/Variables.php
@@ -11,20 +11,21 @@ use AcquiaCloudApi\Response\VariablesResponse;
  *
  * @package AcquiaCloudApi\Endpoints
  */
-class Variables extends CloudApiBase implements CloudApiInterface
+class Variables extends CloudApiBase
 {
     /**
      * Fetches all environment variables.
      *
-     * @param  string $environmentUuid
+     * @param string $environmentUuid
+     *
      * @return VariablesResponse<VariableResponse>
      */
-    public function getAll($environmentUuid): VariablesResponse
+    public function getAll(string $environmentUuid): VariablesResponse
     {
         return new VariablesResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/variables"
+                "/environments/$environmentUuid/variables"
             )
         );
     }
@@ -32,16 +33,17 @@ class Variables extends CloudApiBase implements CloudApiInterface
     /**
      * Returns details about an environment variable.
      *
-     * @param  string $environmentUuid
-     * @param  string $name
+     * @param string $environmentUuid
+     * @param string $name
+     *
      * @return VariableResponse
      */
-    public function get($environmentUuid, $name): VariableResponse
+    public function get(string $environmentUuid, string $name): VariableResponse
     {
         return new VariableResponse(
             $this->client->request(
                 'get',
-                "/environments/${environmentUuid}/variables/${name}"
+                "/environments/$environmentUuid/variables/$name"
             )
         );
     }
@@ -49,12 +51,13 @@ class Variables extends CloudApiBase implements CloudApiInterface
     /**
      * Adds an environment variable.
      *
-     * @param  string $environmentUuid
-     * @param  string $name
-     * @param  string $value
+     * @param string $environmentUuid
+     * @param string $name
+     * @param string $value
+     *
      * @return OperationResponse
      */
-    public function create($environmentUuid, $name, $value): OperationResponse
+    public function create(string $environmentUuid, string $name, string $value): OperationResponse
     {
         $options = [
             'json' => [
@@ -64,19 +67,20 @@ class Variables extends CloudApiBase implements CloudApiInterface
         ];
 
         return new OperationResponse(
-            $this->client->request('post', "/environments/${environmentUuid}/variables", $options)
+            $this->client->request('post', "/environments/$environmentUuid/variables", $options)
         );
     }
 
     /**
      * Updates an environment variable.
      *
-     * @param  string $environmentUuid
-     * @param  string $name
-     * @param  string $value
+     * @param string $environmentUuid
+     * @param string $name
+     * @param string $value
+     *
      * @return OperationResponse
      */
-    public function update($environmentUuid, $name, $value): OperationResponse
+    public function update(string $environmentUuid, string $name, string $value): OperationResponse
     {
         $options = [
             'json' => [
@@ -86,21 +90,22 @@ class Variables extends CloudApiBase implements CloudApiInterface
         ];
 
         return new OperationResponse(
-            $this->client->request('put', "/environments/${environmentUuid}/variables/${name}", $options)
+            $this->client->request('put', "/environments/$environmentUuid/variables/$name", $options)
         );
     }
 
     /**
      * Deletes an environment variable.
      *
-     * @param  string $environmentUuid
-     * @param  string $name
+     * @param string $environmentUuid
+     * @param string $name
+     *
      * @return OperationResponse
      */
-    public function delete($environmentUuid, $name): OperationResponse
+    public function delete(string $environmentUuid, string $name): OperationResponse
     {
         return new OperationResponse(
-            $this->client->request('delete', "/environments/${environmentUuid}/variables/${name}")
+            $this->client->request('delete', "/environments/$environmentUuid/variables/$name")
         );
     }
 }

--- a/src/Response/AccountResponse.php
+++ b/src/Response/AccountResponse.php
@@ -107,7 +107,7 @@ class AccountResponse
     /**
      * @param object $account
      */
-    public function __construct($account)
+    public function __construct(object $account)
     {
         $this->id = $account->id;
         $this->uuid = $account->uuid;

--- a/src/Response/ApplicationResponse.php
+++ b/src/Response/ApplicationResponse.php
@@ -57,7 +57,7 @@ class ApplicationResponse
     /**
      * @param object $application
      */
-    public function __construct($application)
+    public function __construct(object $application)
     {
         $this->id = $application->id;
         $this->uuid = $application->uuid;

--- a/src/Response/ApplicationsResponse.php
+++ b/src/Response/ApplicationsResponse.php
@@ -2,10 +2,12 @@
 
 namespace AcquiaCloudApi\Response;
 
+use ArrayObject;
+
 /**
  * @template-extends \ArrayObject<int, \AcquiaCloudApi\Response\ApplicationResponse>
  */
-class ApplicationsResponse extends \ArrayObject
+class ApplicationsResponse extends ArrayObject
 {
     /**
      * @param array<object> $applications
@@ -14,7 +16,7 @@ class ApplicationsResponse extends \ArrayObject
     {
         parent::__construct(
             array_map(
-                function ($application) {
+                static function ($application) {
                     return new ApplicationResponse($application);
                 },
                 $applications

--- a/src/Response/BackupResponse.php
+++ b/src/Response/BackupResponse.php
@@ -47,7 +47,7 @@ class BackupResponse
     /**
      * @param object $backup
      */
-    public function __construct($backup)
+    public function __construct(object $backup)
     {
         $this->id = $backup->id;
         $this->database = $backup->database;

--- a/src/Response/BackupsResponse.php
+++ b/src/Response/BackupsResponse.php
@@ -2,10 +2,12 @@
 
 namespace AcquiaCloudApi\Response;
 
+use ArrayObject;
+
 /**
  * @template-extends \ArrayObject<int, \AcquiaCloudApi\Response\BackupResponse>
  */
-class BackupsResponse extends \ArrayObject
+class BackupsResponse extends ArrayObject
 {
     /**
      * @param array<object> $backups
@@ -14,7 +16,7 @@ class BackupsResponse extends \ArrayObject
     {
         parent::__construct(
             array_map(
-                function ($backup) {
+                static function ($backup) {
                     return new BackupResponse($backup);
                 },
                 $backups

--- a/src/Response/BranchesResponse.php
+++ b/src/Response/BranchesResponse.php
@@ -2,10 +2,12 @@
 
 namespace AcquiaCloudApi\Response;
 
+use ArrayObject;
+
 /**
  * @template-extends \ArrayObject<int, \AcquiaCloudApi\Response\BranchResponse>
  */
-class BranchesResponse extends \ArrayObject
+class BranchesResponse extends ArrayObject
 {
     /**
      * @param array<object> $branches
@@ -14,7 +16,7 @@ class BranchesResponse extends \ArrayObject
     {
         parent::__construct(
             array_map(
-                function ($branch) {
+                static function ($branch) {
                     return new BranchResponse($branch);
                 },
                 $branches

--- a/src/Response/MetricResponse.php
+++ b/src/Response/MetricResponse.php
@@ -10,7 +10,7 @@ class MetricResponse
     public $metric;
 
     /**
-     * @var array<array> $datapoints
+     * @var array<array<mixed>> $datapoints
      */
     public $datapoints;
 
@@ -32,7 +32,7 @@ class MetricResponse
     /**
      * @param object $metric
      */
-    public function __construct($metric)
+    public function __construct(object $metric)
     {
         $this->metric = $metric->metric;
         $this->datapoints = $metric->datapoints;

--- a/tests/CloudApiTestCase.php
+++ b/tests/CloudApiTestCase.php
@@ -95,7 +95,7 @@ abstract class CloudApiTestCase extends TestCase
      * Uses reflection to retrieve the internal request options to test passed parameters.
      *
      * @param  ClientInterface $client
-     * @return array{json:array}
+     * @return array<mixed>
      */
     protected function getRequestOptions($client): array
     {


### PR DESCRIPTION
The lack of typing on endpoint parameters makes for difficult debugging if a calling library passes the wrong data type. Ran into this on https://github.com/acquia/cli/pull/1126

As long as I'm touching the code, I figured I'd clean up a bunch of other style issues as well.