### PR TITLE
Fix #208: Account IDE endpoint

### DIFF
--- a/src/Endpoints/Ides.php
+++ b/src/Endpoints/Ides.php
@@ -31,6 +31,21 @@ class Ides extends CloudApiBase
     }
 
     /**
+     * Returns a list of the current user's IDEs.
+     *
+     * @return IdesResponse<IdeResponse>
+     */
+    public function getMine(): IdesResponse
+    {
+        return new IdesResponse(
+            $this->client->request(
+                'get',
+                '/account/ides'
+            )
+        );
+    }
+
+    /**
      * Get remote IDE info.
      *
      * @param string $ideUuid The Remote IDE universally unique identifier.

--- a/src/Response/IdeResponse.php
+++ b/src/Response/IdeResponse.php
@@ -32,6 +32,8 @@ class IdeResponse
         $this->uuid = $ide->uuid;
         $this->label = $ide->label;
         $this->links = $ide->_links;
-        $this->owner = new MemberResponse($ide->_embedded->owner);
+        if (isset($ide->_embedded->owner)) {
+            $this->owner = new MemberResponse($ide->_embedded->owner);
+        }
     }
 }

--- a/tests/Endpoints/IdesTest.php
+++ b/tests/Endpoints/IdesTest.php
@@ -4,13 +4,15 @@ namespace AcquiaCloudApi\Tests\Endpoints;
 
 use AcquiaCloudApi\Tests\CloudApiTestCase;
 use AcquiaCloudApi\Endpoints\Ides;
+use AcquiaCloudApi\Response\IdeResponse;
+use AcquiaCloudApi\Response\OperationResponse;
 
 class IdesTest extends CloudApiTestCase
 {
     /**
-     * @var mixed[] $properties
+     * @var array<string> $properties
      */
-    public $properties = [
+    public array $properties = [
         'uuid',
         'label',
         'links',
@@ -23,7 +25,6 @@ class IdesTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Ides/getAllIdes.json');
         $client = $this->getMockClient($response);
 
-        /** @var \AcquiaCloudApi\Connector\ClientInterface $client */
         $ide = new Ides($client);
         $result = $ide->getAll('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851');
 
@@ -32,7 +33,29 @@ class IdesTest extends CloudApiTestCase
         $this->assertNotEmpty($result);
 
         foreach ($result as $record) {
-            $this->assertInstanceOf('\AcquiaCloudApi\Response\IdeResponse', $record);
+            $this->assertInstanceOf(IdeResponse::class, $record);
+
+            foreach ($this->properties as $property) {
+                $this->assertObjectHasAttribute($property, $record);
+            }
+        }
+    }
+
+    public function testGetMyIdes(): void
+    {
+
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/Ides/getAllIdes.json');
+        $client = $this->getMockClient($response);
+
+        $ide = new Ides($client);
+        $result = $ide->getMine();
+
+        $this->assertInstanceOf('\ArrayObject', $result);
+        $this->assertInstanceOf('\AcquiaCloudApi\Response\IdesResponse', $result);
+        $this->assertNotEmpty($result);
+
+        foreach ($result as $record) {
+            $this->assertInstanceOf(IdeResponse::class, $record);
 
             foreach ($this->properties as $property) {
                 $this->assertObjectHasAttribute($property, $record);
@@ -45,12 +68,11 @@ class IdesTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Ides/getIde.json');
         $client = $this->getMockClient($response);
 
-        /** @var \AcquiaCloudApi\Connector\ClientInterface $client */
         $ide = new Ides($client);
         $result = $ide->get('8ff6c046-ec64-4ce4-bea6-27845ec18600');
 
         $this->assertNotInstanceOf('\AcquiaCloudApi\Response\IdesResponse', $result);
-        $this->assertInstanceOf('\AcquiaCloudApi\Response\IdeResponse', $result);
+        $this->assertInstanceOf(IdeResponse::class, $result);
 
         foreach ($this->properties as $property) {
               $this->assertObjectHasAttribute($property, $result);
@@ -62,7 +84,6 @@ class IdesTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Ides/createIde.json');
         $client = $this->getMockClient($response);
 
-        /** @var \AcquiaCloudApi\Connector\ClientInterface $client */
         $ide = new Ides($client);
         $result = $ide->create(
             '14-0c7e79ab-1c4a-424e-8446-76ae8be7e851',
@@ -76,7 +97,7 @@ class IdesTest extends CloudApiTestCase
         ];
 
         $this->assertEquals($requestOptions, $this->getRequestOptions($client));
-        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $this->assertInstanceOf(OperationResponse::class, $result);
         $this->assertEquals('The remote IDE is being created.', $result->message);
     }
 
@@ -85,11 +106,10 @@ class IdesTest extends CloudApiTestCase
         $response = $this->getPsr7JsonResponseForFixture('Endpoints/Ides/deleteIde.json');
         $client = $this->getMockClient($response);
 
-        /** @var \AcquiaCloudApi\Connector\ClientInterface $client */
         $ide = new Ides($client);
         $result = $ide->delete('14-0c7e79ab-1c4a-424e-8446-76ae8be7e851');
 
-        $this->assertInstanceOf('\AcquiaCloudApi\Response\OperationResponse', $result);
+        $this->assertInstanceOf(OperationResponse::class, $result);
         $this->assertEquals('The remote IDE is being deleted.', $result->message);
     }
 }


### PR DESCRIPTION
The [response from the account ides endpoint](https://cloudapi-docs.acquia.com/#/Account/getAccountIdes) does not include owner information. Populating it would require fixing that endpoint via a CXAPI ticket or making another API call. Probably easiest just to make the owner info nullable on the IDE response.