### PR TITLE
Fix mutation tests on push

### DIFF
--- a/.github/workflows/mt.yml
+++ b/.github/workflows/mt.yml
@@ -33,8 +33,14 @@ jobs:
           chmod +x infection.phar
 
       - name: Run Infection for added files only
-        env:
-          INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
+        if: github.event_name == 'pull_request'
         run: |
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          php infection.phar -j2 --git-diff-filter=A --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --ignore-msi-with-no-mutations --only-covered
+          php infection.phar -j8 --git-diff-filter=A --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --ignore-msi-with-no-mutations --only-covered
+
+      - name: Run Infection for all files
+        if: github.event_name == 'push'
+        env:
+            INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
+        run: |
+            php infection.phar -j8 --ignore-msi-with-no-mutations --only-covered


### PR DESCRIPTION
[Tests are broken in master](https://github.com/typhonius/acquia-php-sdk-v2/actions/runs/4128073809/jobs/7132070555). In fact, they have been for a while but it wasn't obvious until we updated Infection and it started properly returning a non-zero exit code on these failures: https://github.com/infection/infection/pull/1600