### PR TITLE
Environment region can be null

### DIFF
--- a/src/Response/EnvironmentResponse.php
+++ b/src/Response/EnvironmentResponse.php
@@ -30,7 +30,7 @@ class EnvironmentResponse
      */
     public array $ips;
 
-    public string $region;
+    public ?string $region;
 
     public string $status;
 


### PR DESCRIPTION
It shouldn't be possible for region to be null according to the docs, but it's happened at least once. I'll open an internal ticket for this.