### PR TITLE
CLI-1026: Catch malformed responses

### DIFF
--- a/src/Connector/Client.php
+++ b/src/Connector/Client.php
@@ -2,6 +2,7 @@
 
 namespace AcquiaCloudApi\Connector;
 
+use http\Exception\RuntimeException;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Exception\BadResponseException;
 use AcquiaCloudApi\Exception\ApiErrorException;
@@ -152,7 +153,15 @@ class Client implements ClientInterface
     {
 
         $body_json = $response->getBody();
-        $body = json_decode($body_json);
+        $body = json_decode($body_json, null, 512, JSON_THROW_ON_ERROR);
+        if (is_null($body)) {
+            throw new RuntimeException(
+                'Response contained an empty body. Status '
+                . $response->getStatusCode()
+                . '. Request ID '
+                . $response->getHeaderLine('X-Request-Id')
+            );
+        }
 
         if (property_exists($body, '_embedded') && property_exists($body->_embedded, 'items')) {
             return $body->_embedded->items;


### PR DESCRIPTION
We are seeing a lot of errors like `property_exists(): Argument #1 ($object_or_class) must be of type object|string, null given` in Client::processResponse(). This occurs when the body of the response is empty. Logs indicate the API returning 200 for these requests.

The only way I could imagine this happening is if the API is returning a truly empty response. Since it's returning a 200 response, it can't be caught as a BadResponseException in Client::makeRequest(), and any other type of connection error (i.e., connection reset) should generate an exception prior to the typeerror being thrown (barring a bug like https://github.com/guzzle/guzzle/issues/2203).

Anyway, checking for an empty body and logging additional details about the request will help diagnose this. Since this is basically debugging code, I'm not trying to make it pretty. If it's going to be permanent, the exception should probably be its own class.