### PR TITLE
CLI-1133: FedAuth API calls require org scope

### DIFF
--- a/src/Connector/Connector.php
+++ b/src/Connector/Connector.php
@@ -64,7 +64,7 @@ class Connector implements ConnectorInterface
             'clientSecret'            => $config['secret'],
             'urlAuthorize'            => '',
             'urlAccessToken'          => $this->getUrlAccessToken(),
-            'urlResourceOwnerDetails' => ''
+            'urlResourceOwnerDetails' => '',
             ]
         );
 

--- a/src/Connector/Connector.php
+++ b/src/Connector/Connector.php
@@ -46,12 +46,8 @@ class Connector implements ConnectorInterface
     /**
      * @param array<string, string> $config
      */
-    public function __construct(
-        array $config,
-        string $base_uri = null,
-        string $url_access_token = null,
-        string $scopes = ''
-    ) {
+    public function __construct(array $config, string $base_uri = null, string $url_access_token = null)
+    {
         $this->baseUri = ConnectorInterface::BASE_URI;
         if ($base_uri) {
             $this->baseUri = $base_uri;
@@ -64,12 +60,11 @@ class Connector implements ConnectorInterface
 
         $this->provider = new GenericProvider(
             [
-                'clientId'                => $config['key'],
-                'clientSecret'            => $config['secret'],
-                'urlAuthorize'            => '',
-                'urlAccessToken'          => $this->getUrlAccessToken(),
-                'urlResourceOwnerDetails' => '',
-                'scopes' => $scopes,
+            'clientId'                => $config['key'],
+            'clientSecret'            => $config['secret'],
+            'urlAuthorize'            => '',
+            'urlAccessToken'          => $this->getUrlAccessToken(),
+            'urlResourceOwnerDetails' => ''
             ]
         );
 
@@ -97,7 +92,11 @@ class Connector implements ConnectorInterface
             /** @infection-ignore-all */
             $cache = new FilesystemAdapter('cache', 300, $directory);
             $accessToken = $cache->get('cloudapi-token', function () {
-                return $this->provider->getAccessToken('client_credentials');
+                $options = [];
+                if ($orgUuid = getenv('AH_ORGANIZATION_UUID')) {
+                    $options['scope'] = 'organization:' . $orgUuid;
+                }
+                return $this->provider->getAccessToken('client_credentials', $options);
             });
 
             $this->accessToken = $accessToken;

--- a/src/Connector/Connector.php
+++ b/src/Connector/Connector.php
@@ -46,8 +46,12 @@ class Connector implements ConnectorInterface
     /**
      * @param array<string, string> $config
      */
-    public function __construct(array $config, string $base_uri = null, string $url_access_token = null)
-    {
+    public function __construct(
+        array $config,
+        string $base_uri = null,
+        string $url_access_token = null,
+        string $scopes = ''
+    ) {
         $this->baseUri = ConnectorInterface::BASE_URI;
         if ($base_uri) {
             $this->baseUri = $base_uri;
@@ -60,11 +64,12 @@ class Connector implements ConnectorInterface
 
         $this->provider = new GenericProvider(
             [
-            'clientId'                => $config['key'],
-            'clientSecret'            => $config['secret'],
-            'urlAuthorize'            => '',
-            'urlAccessToken'          => $this->getUrlAccessToken(),
-            'urlResourceOwnerDetails' => '',
+                'clientId'                => $config['key'],
+                'clientSecret'            => $config['secret'],
+                'urlAuthorize'            => '',
+                'urlAccessToken'          => $this->getUrlAccessToken(),
+                'urlResourceOwnerDetails' => '',
+                'scopes' => $scopes,
             ]
         );
 


### PR DESCRIPTION
This isn't easily tested in automated tests because we mock the stream body that would ordinarily contain these params.