### PR TITLE
Revert "Update DatabaseResponse.php (#469)"

### DIFF
--- a/src/Response/DatabaseResponse.php
+++ b/src/Response/DatabaseResponse.php
@@ -8,11 +8,11 @@ class DatabaseResponse
     public string $name;
     // Connection details will be missing without the required permission:
     // "View database connection details (username, password, or hostname)"
-    public string $user_name;
-    public string $password;
-    public string $url;
+    public ?string $user_name;
+    public ?string $password;
+    public ?string $url;
     public string $db_host;
-    public string $ssh_host;
+    public ?string $ssh_host;
     public object $flags;
     public object $environment;
 
@@ -20,11 +20,11 @@ class DatabaseResponse
     {
         $this->id = $database->id;
         $this->name = $database->name;
-        $this->user_name = $database->user_name;
-        $this->password = $database->password;
-        $this->url = $database->url;
+        $this->user_name = $database->user_name ?? null;
+        $this->password = $database->password ?? null;
+        $this->url = $database->url ?? null;
         $this->db_host = $database->db_host;
-        $this->ssh_host = $database->ssh_host;
+        $this->ssh_host = $database->ssh_host ?? null;
         $this->flags = $database->flags;
         $this->environment = $database->environment;
     }


### PR DESCRIPTION
This reverts commit 7cc0c773ea15d82ab7268266097c846d5814be87.

Reverts #469 

Being prescriptive has caused a lot of support requests, and makes this harder to work around downstream without suppressing warnings in the method call.

Ugly as it is, I think this library needs to remain descriptive.