### PR TITLE
CLI-1563: Handle Okta errors

### DIFF
--- a/src/Connector/Connector.php
+++ b/src/Connector/Connector.php
@@ -2,6 +2,7 @@
 
 namespace AcquiaCloudApi\Connector;
 
+use AcquiaCloudApi\Connector\OktaProvider;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\GenericProvider;
 use League\OAuth2\Client\Token\AccessTokenInterface;
@@ -65,7 +66,7 @@ class Connector implements ConnectorInterface
 
         $this->clientId = $config['key'];
 
-        $this->provider = new GenericProvider(
+        $this->provider = new OktaProvider(
             [
             'clientId'                => $config['key'],
             'clientSecret'            => $config['secret'],

--- a/src/Connector/OktaProvider.php
+++ b/src/Connector/OktaProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace AcquiaCloudApi\Connector;
+
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Provider\GenericProvider;
+use Psr\Http\Message\ResponseInterface;
+
+class OktaProvider extends GenericProvider
+{
+    /**
+     * @inheritDoc
+     */
+    protected function checkResponse(ResponseInterface $response, $data): void
+    {
+        if (!empty($data['errorCode'])) {
+            $error = $data['errorCode'];
+            if (!is_string($error)) {
+                $error = var_export($error, true);
+            }
+            throw new IdentityProviderException($error, 0, $data);
+        }
+        parent::checkResponse($response, $data);
+    }
+}


### PR DESCRIPTION
Acquia ID uses Okta, which doesn't provide a simple `error` property in response to bad requests, but rather separate `errorCode` and `errorSummary` properties. This causes the response to not be detected as an error by the League OAuth provider, and thus to not be caught by Acquia CLI's error handler either.