### PR TITLE
#520: Ensure `$links` is an object when constructing SiteResponse.

### DIFF
--- a/src/Response/SiteResponse.php
+++ b/src/Response/SiteResponse.php
@@ -26,6 +26,9 @@ class SiteResponse
         $this->label = $site->label;
         $this->description = $site->description ?? null;
         $this->codebaseId = $site->codebase_id ?? null;
-        $this->links = $site->_links;
+
+        // Make sure $links is always an object, whether it's null, missing, or an array
+        $links = $siteInstance->_links ?? [];
+        $this->links = is_object($links) ? $links : (object) $links;
     }
 }


### PR DESCRIPTION
Resolves the $links cannot be null issue with the same code pattern as used in `SiteInstanceResponse`