### PR TITLE
#529: Added database connection details endpoint and response and updated existing endpoint.

### DIFF
--- a/src/Endpoints/SiteInstances.php
+++ b/src/Endpoints/SiteInstances.php
@@ -7,6 +7,7 @@ use AcquiaCloudApi\Response\DomainsResponse;
 use AcquiaCloudApi\Response\OperationResponse;
 use AcquiaCloudApi\Response\SiteInstanceDatabaseBackupResponse;
 use AcquiaCloudApi\Response\SiteInstanceDatabaseBackupsResponse;
+use AcquiaCloudApi\Response\SiteInstanceDatabaseConnectionResponse;
 use AcquiaCloudApi\Response\SiteInstanceResponse;
 use AcquiaCloudApi\Response\SiteInstanceDatabaseResponse;
 
@@ -39,6 +40,19 @@ class SiteInstances extends CloudApiBase
             $this->client->request(
                 'get',
                 "/site-instances/$siteId.$environmentId/database"
+            )
+        );
+    }
+
+    /**
+     * Returns database connection details for a site instance.
+     */
+    public function getDatabaseConnection(string $siteId, string $environmentId): SiteInstanceDatabaseConnectionResponse
+    {
+        return new SiteInstanceDatabaseConnectionResponse(
+            $this->client->request(
+                'get',
+                "/site-instances/$siteId.$environmentId/database/connection"
             )
         );
     }

--- a/src/Response/SiteInstanceDatabaseConnectionResponse.php
+++ b/src/Response/SiteInstanceDatabaseConnectionResponse.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AcquiaCloudApi\Response;
+
+class SiteInstanceDatabaseConnectionResponse
+{
+    public string $databaseHost;
+
+    public string $databaseName;
+
+    public string $databasePassword;
+
+    public string $databaseUserName;
+
+    public string $sshHost;
+
+    public object $links;
+
+    public function __construct(object $database)
+    {
+        $this->databaseHost = $database->db_host;
+        $this->databaseName = $database->name;
+        $this->databasePassword = $database->password;
+        $this->databaseUserName = $database->user_name;
+        $this->sshHost = $database->ssh_host;
+        $this->links = $database->_links;
+    }
+}

--- a/src/Response/SiteInstanceDatabaseResponse.php
+++ b/src/Response/SiteInstanceDatabaseResponse.php
@@ -4,25 +4,17 @@ namespace AcquiaCloudApi\Response;
 
 class SiteInstanceDatabaseResponse
 {
-    public string $databaseHost;
 
     public string $databaseName;
 
     public string $databaseRole;
 
-    public string $databaseUserName;
-
-    public string $databasePassword;
-
     public object $links;
 
     public function __construct(object $database)
     {
-        $this->databaseHost = $database->database_host;
         $this->databaseName = $database->database_name;
         $this->databaseRole = $database->database_role;
-        $this->databaseUserName = $database->database_user_name;
-        $this->databasePassword = $database->database_password;
         $this->links = $database->_links;
     }
 }

--- a/src/Response/SiteInstanceDatabaseResponse.php
+++ b/src/Response/SiteInstanceDatabaseResponse.php
@@ -4,7 +4,6 @@ namespace AcquiaCloudApi\Response;
 
 class SiteInstanceDatabaseResponse
 {
-
     public string $databaseName;
 
     public string $databaseRole;

--- a/tests/Endpoints/SiteInstancesTest.php
+++ b/tests/Endpoints/SiteInstancesTest.php
@@ -2,6 +2,7 @@
 
 namespace AcquiaCloudApi\Tests\Endpoints;
 
+use AcquiaCloudApi\Response\SiteInstanceDatabaseConnectionResponse;
 use AcquiaCloudApi\Tests\CloudApiTestCase;
 use AcquiaCloudApi\Endpoints\SiteInstances;
 use AcquiaCloudApi\Response\SiteInstanceResponse;
@@ -48,11 +49,27 @@ class SiteInstancesTest extends CloudApiTestCase
         );
 
         $this->assertInstanceOf(SiteInstanceDatabaseResponse::class, $result);
-        $this->assertEquals('localhost', $result->databaseHost);
         $this->assertEquals('example_db', $result->databaseName);
         $this->assertEquals('primary', $result->databaseRole);
-        $this->assertEquals('example_user', $result->databaseUserName);
-        $this->assertEquals('example_password', $result->databasePassword);
+    }
+
+    public function testGetSiteInstanceDatabaseConnection(): void
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/SiteInstances/getSiteInstanceDatabaseConnection.json');
+        $client = $this->getMockClient($response);
+
+        $siteInstances = new SiteInstances($client);
+        $result = $siteInstances->getDatabaseConnection(
+            '3e8ecbec-ea7c-4260-8414-ef2938c859bc',
+            'd3f7270e-c45f-4801-9308-5e8afe84a323'
+        );
+
+        $this->assertInstanceOf(SiteInstanceDatabaseConnectionResponse::class, $result);
+        $this->assertEquals('example_db', $result->databaseName);
+        $this->assertEquals('example', $result->databaseUserName);
+        $this->assertEquals('example@123', $result->databasePassword);
+        $this->assertEquals('localhost', $result->databaseHost);
+        $this->assertEquals('ssh://example.com', $result->sshHost);
     }
 
     public function testCopyDatabase(): void
@@ -307,11 +324,28 @@ class SiteInstancesTest extends CloudApiTestCase
         );
 
         $this->assertInstanceOf(SiteInstanceDatabaseResponse::class, $result);
-        $this->assertNotNull($result->databaseHost);
         $this->assertNotNull($result->databaseName);
         $this->assertNotNull($result->databaseRole);
+        $this->assertIsObject($result->links);
+    }
+
+    public function testDatabaseConnectionResponseTransformations(): void
+    {
+        $response = $this->getPsr7JsonResponseForFixture('Endpoints/SiteInstances/getSiteInstanceDatabaseConnection.json');
+        $client = $this->getMockClient($response);
+
+        $siteInstances = new SiteInstances($client);
+        $result = $siteInstances->getDatabaseConnection(
+            '3e8ecbec-ea7c-4260-8414-ef2938c859bc',
+            'd3f7270e-c45f-4801-9308-5e8afe84a323'
+        );
+
+        $this->assertInstanceOf(SiteInstanceDatabaseConnectionResponse::class, $result);
+        $this->assertNotNull($result->databaseName);
+        $this->assertNotNull($result->databaseHost);
         $this->assertNotNull($result->databaseUserName);
         $this->assertNotNull($result->databasePassword);
+        $this->assertNotNull($result->sshHost);
         $this->assertIsObject($result->links);
     }
 

--- a/tests/Endpoints/SiteInstancesTest.php
+++ b/tests/Endpoints/SiteInstancesTest.php
@@ -55,7 +55,9 @@ class SiteInstancesTest extends CloudApiTestCase
 
     public function testGetSiteInstanceDatabaseConnection(): void
     {
-        $response = $this->getPsr7JsonResponseForFixture('Endpoints/SiteInstances/getSiteInstanceDatabaseConnection.json');
+        $response = $this->getPsr7JsonResponseForFixture(
+            'Endpoints/SiteInstances/getSiteInstanceDatabaseConnection.json'
+        );
         $client = $this->getMockClient($response);
 
         $siteInstances = new SiteInstances($client);
@@ -331,7 +333,9 @@ class SiteInstancesTest extends CloudApiTestCase
 
     public function testDatabaseConnectionResponseTransformations(): void
     {
-        $response = $this->getPsr7JsonResponseForFixture('Endpoints/SiteInstances/getSiteInstanceDatabaseConnection.json');
+        $response = $this->getPsr7JsonResponseForFixture(
+            'Endpoints/SiteInstances/getSiteInstanceDatabaseConnection.json'
+        );
         $client = $this->getMockClient($response);
 
         $siteInstances = new SiteInstances($client);

--- a/tests/Fixtures/Endpoints/SiteInstances/getSiteInstanceDatabase.json
+++ b/tests/Fixtures/Endpoints/SiteInstances/getSiteInstanceDatabase.json
@@ -4,9 +4,6 @@
       "href": "https://environment-service-php.acquia.com/api/site-instances/3e8ecbec-ea7c-4260-8414-ef2938c859bc.d3f7270e-c45f-4801-9308-5e8afe84a323/database"
     }
   },
-  "database_host": "localhost",
   "database_name": "example_db",
-  "database_role": "primary",
-  "database_user_name": "example_user",
-  "database_password": "example_password"
+  "database_role": "primary"
 }

--- a/tests/Fixtures/Endpoints/SiteInstances/getSiteInstanceDatabaseConnection.json
+++ b/tests/Fixtures/Endpoints/SiteInstances/getSiteInstanceDatabaseConnection.json
@@ -1,0 +1,12 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://environment-service-php.acquia.com/api/site-instances/3e8ecbec-ea7c-4260-8414-ef2938c859bc.d3f7270e-c45f-4801-9308-5e8afe84a323/database/connection"
+    }
+  },
+  "db_host": "localhost",
+  "name": "example_db",
+  "password": "example@123",
+  "user_name": "example",
+  "ssh_host": "ssh://example.com"
+}


### PR DESCRIPTION
This pull request introduces a new API method to retrieve database connection details for a site instance, along with a dedicated response class and corresponding tests. It also refactors the existing database response to remove connection-specific fields, ensuring a clear separation of concerns between metadata and connection information.

**New functionality:**

* Added a new method `getDatabaseConnection` to the `SiteInstances` endpoint, which returns database connection details for a site instance.
* Introduced a new response class, `SiteInstanceDatabaseConnectionResponse`, to encapsulate database connection information such as host, username, password, and SSH host.

**Refactoring and cleanup:**

* Removed connection-specific fields (`databaseHost`, `databaseUserName`, `databasePassword`) from `SiteInstanceDatabaseResponse`, so it now only contains database metadata.
* Updated the test fixture `getSiteInstanceDatabase.json` to remove connection fields, reflecting the refactored response.
* Added a new test fixture `getSiteInstanceDatabaseConnection.json` for the new connection endpoint.

**Testing:**

* Added new tests for `getDatabaseConnection` and `SiteInstanceDatabaseConnectionResponse`, verifying correct parsing and field mapping. [[1]](diffhunk://#diff-3e4d1b55b98275581941656e1bbc6c9f59793121d948cf7f15d1cccb2c06c491L51-R72) [[2]](diffhunk://#diff-3e4d1b55b98275581941656e1bbc6c9f59793121d948cf7f15d1cccb2c06c491L310-R348)
* Updated existing tests to match the refactored structure of `SiteInstanceDatabaseResponse`. [[1]](diffhunk://#diff-3e4d1b55b98275581941656e1bbc6c9f59793121d948cf7f15d1cccb2c06c491L51-R72) [[2]](diffhunk://#diff-3e4d1b55b98275581941656e1bbc6c9f59793121d948cf7f15d1cccb2c06c491L310-R348)

These changes improve clarity in the API by separating database metadata from connection details and provide comprehensive test coverage for the new and updated functionality.